### PR TITLE
feat: switch Docker publishing to ghcr.io and update secret references

### DIFF
--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -51,12 +51,12 @@ jobs:
             gh pr close "$PR" --comment "Superseded by newer OpenAPI sync" || true
           done
         env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Download OpenAPI specs from enriched source
         run: npm run sync-specs
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Get version info
         id: version
@@ -136,7 +136,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true' || github.event.inputs.force_regenerate == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           add-paths: |
             src/tools/
             tests/fixtures/
@@ -180,7 +180,7 @@ jobs:
         run: |
           gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --squash
         env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Summary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,12 +211,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -231,8 +225,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/f5xc-api-mcp:${{ needs.release.outputs.npm_version }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/f5xc-api-mcp:latest
             ghcr.io/${{ github.repository }}:${{ needs.release.outputs.npm_version }}
             ghcr.io/${{ github.repository }}:latest
           labels: |

--- a/.github/workflows/update-f5xc-auth.yml
+++ b/.github/workflows/update-f5xc-auth.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.updated == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           commit-message: |
             chore(deps): update f5xc-auth to ${{ github.event.client_payload.version }}
 


### PR DESCRIPTION
## Summary

- Remove DockerHub login and tags from `release.yml` — publish Docker images exclusively to `ghcr.io/f5xc-salesdemos/api-mcp`
- Replace `REPO_ADMIN_TOKEN` with `RELEASE_TOKEN` in `openapi-sync.yml` (4 occurrences) and `update-f5xc-auth.yml` (1 occurrence)
- Repository secrets configured: `REPO_SYNC_TOKEN`, `REPO_SETTINGS_TOKEN`, `RELEASE_TOKEN`, `NPM_TOKEN`

## Motivation

The Release workflow failed after PR #6 migration because DockerHub secrets weren't configured. Rather than adding DockerHub secrets, this switches to ghcr.io exclusively (matching the docs-builder pattern).

## Test plan

- [ ] CI checks pass on this PR
- [ ] Post-merge: Release workflow builds and pushes Docker image to ghcr.io
- [ ] Post-merge: `docker pull ghcr.io/f5xc-salesdemos/api-mcp:latest` succeeds
- [ ] Post-merge: npm publish succeeds
- [ ] Enforce Repo Settings workflow passes with new secrets

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)