### PR TITLE
fix: add npm provenance publishing to bypass OTP requirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm
-        run: npm publish --access public --tag latest
+        run: npm publish --access public --tag latest --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   mcpb:
     name: MCPB Bundle


### PR DESCRIPTION
## Summary

- Add `--provenance` flag to `npm publish` command, matching the docs-theme pattern
- Set `NPM_TOKEN` env var alongside `NODE_AUTH_TOKEN` for compatibility
- The workflow already has `id-token: write` permission, enabling OIDC-based provenance

## Motivation

The Release workflow failed at npm publish with `EOTP` error because the npm account has 2FA enabled. docs-theme avoids this by using `@semantic-release/npm` which automatically publishes with provenance via GitHub OIDC — bypassing the OTP requirement.

## Test plan

- [ ] CI checks pass on this PR
- [ ] Post-merge: Release workflow npm publish succeeds with provenance
- [ ] Post-merge: Docker image pushed to ghcr.io
- [ ] Post-merge: MCPB bundle created

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)