### PR TITLE
fix: correct naming inconsistencies in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# API MCP
+# F5XC API MCP
 
 [![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/api-mcp/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/api-mcp/actions/workflows/github-pages-deploy.yml)
 [![Repo Settings](https://github.com/f5xc-salesdemos/api-mcp/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/api-mcp/actions/workflows/enforce-repo-settings.yml)

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: API MCP Server
+title: F5XC API MCP Server
 description: MCP server exposing Cloud APIs to AI assistants
 hero:
   tagline: 1,500+ API tools with dynamic discovery and 95%+ token savings

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -33,7 +33,7 @@ docker run -it ghcr.io/f5xc-salesdemos/api-mcp
 
 ```bash
 git clone https://github.com/f5xc-salesdemos/api-mcp.git
-cd f5xc-api-mcp
+cd api-mcp
 npm install && npm run build && npm start
 ```
 


### PR DESCRIPTION
## Summary
- Fix wrong `cd` directory in "From Source" installation docs (`cd f5xc-api-mcp` → `cd api-mcp`)
- Update README title from `API MCP` to `F5XC API MCP`
- Update docs landing page title from `API MCP Server` to `F5XC API MCP Server`

## Motivation
After migration from `robinmordasiewicz/f5xc-api-mcp` to `f5xc-SalesDemos/api-mcp`, the `git clone` command creates a directory named `api-mcp` (matching the repo name), but the install docs incorrectly had `cd f5xc-api-mcp`. The README and docs titles were also too generic.

## Test plan
- [x] `npm run build` — no compilation errors
- [x] `node dist/index.js --version` — outputs `f5xc-api-mcp v2.0.21-2601122132`
- [x] `git diff` — only 3 files modified with expected changes
- [ ] CI checks pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)