### PR TITLE
docs: fix grammar, phrasing, and style issues in documentation

### DIFF
--- a/docs/architecture/0004-external-auth-package.mdx
+++ b/docs/architecture/0004-external-auth-package.mdx
@@ -24,11 +24,11 @@ Should this authentication logic be embedded in the MCP server, or extracted to 
 
 ## Decision Drivers
 
-- Code Reusability - Authentication logic useful for other F5 XC tools
-- Separation of Concerns - Authentication is distinct from MCP server logic
-- Security - Dedicated focus on credential management and security
-- Maintainability - Easier to test and update independently
-- Multi-Project Use - Other projects need similar authentication
+* Code Reusability - Authentication logic useful for other F5 XC tools
+* Separation of Concerns - Authentication is distinct from MCP server logic
+* Security - Dedicated focus on credential management and security
+* Maintainability - Easier to test and update independently
+* Multi-Project Use - Other projects need similar authentication
 
 ## Considered Options
 

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -108,7 +108,7 @@ For managing multiple F5XC tenant credentials, use profiles stored in `~/.config
 
 ### Using the Configure Auth Tool
 
-The easiest way to configure authentication is through Claude. Ask Claude to configure authentication:
+The easiest way to set up authentication is through Claude. Ask it to configure your credentials:
 
 > "Configure F5XC authentication with my tenant"
 

--- a/docs/reference/resource-uris.mdx
+++ b/docs/reference/resource-uris.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-Access F5XC resources via URI scheme:
+The server uses a URI scheme to reference F5 XC API resources. The general format is:
 
 ```text
 f5xc://{tenant}/{namespace}/{resource-type}/{name}

--- a/docs/reference/server-defaults.mdx
+++ b/docs/reference/server-defaults.mdx
@@ -5,8 +5,8 @@ sidebar:
   order: 2
 ---
 
-F5 XC API specifications distinguish between field requirements with
-enhanced metadata, reducing the number of fields you must provide.
+The F5 XC API uses enhanced metadata to distinguish between field requirement
+types, reducing the number of fields you must provide.
 
 > Available since v2.0.28
 

--- a/docs/reference/workflow-prompts.mdx
+++ b/docs/reference/workflow-prompts.mdx
@@ -5,8 +5,7 @@ sidebar:
   order: 4
 ---
 
-The server includes guided workflow prompts sourced from upstream enriched specs
-for common multi-step F5XC operations.
+The server includes guided workflow prompts for common multi-step F5XC operations.
 
 | Prompt                      | Description                                                           |
 | --------------------------- | --------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

- Rewrite terse fragment in `resource-uris.mdx` into a proper introductory sentence
- Remove unclear jargon ("sourced from upstream enriched specs") from `workflow-prompts.mdx`
- Clarify awkward opening phrasing in `server-defaults.mdx`
- Fix repetitive phrasing ("configure authentication... configure authentication") in `authentication.mdx`
- Standardize bullet markers from `-` to `*` in ADR-0004 for consistency with other ADRs

Closes #19

## Test plan

- [ ] Verify docs build succeeds in CI
- [ ] Confirm no MDX syntax errors introduced
- [ ] Spot-check edited pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)