### PR TITLE
fix: add sidebar frontmatter to index.mdx for correct nav ordering

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: API MCP
 description: Access 1,500+ F5 Distributed Cloud APIs through AI assistants like Claude
+sidebar:
+  order: 1
+  hidden: true
 hero:
   tagline: 1,500+ API tools with dynamic discovery and 95%+ token savings
 ---


### PR DESCRIPTION
## Summary
- Add `sidebar.order: 1` and `sidebar.hidden: true` to `docs/index.mdx` so the homepage sorts first internally but stays hidden from the left nav
- Fixes sidebar showing `architecture/` above `installation.mdx` due to missing order metadata

Closes #25

## Test plan
- [ ] Verify `index.mdx` does not appear in the sidebar
- [ ] Verify `installation.mdx` appears as the first visible sidebar item
- [ ] Verify `architecture/` sorts after individually-ordered pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)