### PR TITLE
docs: replace hero tagline with informative project description

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,5 +5,5 @@ sidebar:
   order: 1
   hidden: true
 hero:
-  tagline: 1,500+ API tools with dynamic discovery and 95%+ token savings
+  tagline: An MCP server that enables AI assistants to manage F5 Distributed Cloud services through the platform API
 ---


### PR DESCRIPTION
## Summary
- Replace marketing-style tagline with a clear description of what the project does
- Old: "1,500+ API tools with dynamic discovery and 95%+ token savings"
- New: "An MCP server that enables AI assistants to manage F5 Distributed Cloud services through the platform API"

Closes #27

## Test plan
- [ ] Verify the new tagline renders correctly on the docs homepage
- [ ] Confirm the tagline clearly communicates the project's purpose

🤖 Generated with [Claude Code](https://claude.com/claude-code)