### PR TITLE
feat: add AI assistant hero image to landing page

### DIFF
--- a/docs/images/hero.svg
+++ b/docs/images/hero.svg
@@ -1,0 +1,18 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12.0611" cy="12.061" r="11.8624" fill="url(#paint0_linear_27342_9117)"/>
+<circle cx="12" cy="11.9998" r="11.8624" fill="url(#paint1_linear_27342_9117)"/>
+<defs>
+<linearGradient id="paint0_linear_27342_9117" x1="0.19873" y1="7.04233" x2="14.3423" y2="28.0296" gradientUnits="userSpaceOnUse">
+<stop offset="0.160163" stop-color="white"/>
+<stop offset="0.506552" stop-color="#25E3E3"/>
+<stop offset="0.803577" stop-color="#CA91EC"/>
+<stop offset="1" stop-color="#7E00CB"/>
+</linearGradient>
+<linearGradient id="paint1_linear_27342_9117" x1="18" y1="4.36366" x2="6.00003" y2="25.0909" gradientUnits="userSpaceOnUse">
+<stop offset="0.160163" stop-color="white" stop-opacity="0.64"/>
+<stop offset="0.506552" stop-color="#00509A" stop-opacity="0.55"/>
+<stop offset="0.803577" stop-color="#FF6363" stop-opacity="0.53"/>
+<stop offset="1" stop-color="#9B9B9B" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,4 +6,6 @@ sidebar:
   hidden: true
 hero:
   tagline: An MCP server that enables AI assistants to manage F5 Distributed Cloud services through the platform API
+  image:
+    html: '<img src="/api-mcp/images/hero.svg" alt="F5 XC API MCP" />'
 ---


### PR DESCRIPTION
## Summary

- Add service-specific hero image (`ai_assistant_logo`) to the api-mcp landing page
- Source SVG from `docs-icons` with `width`/`height` attributes removed (viewBox preserved for responsive sizing)
- No dark-mode override needed — gradient renders well on both backgrounds

Closes #31

## Test plan

- [ ] CI checks pass (linked-issue, markdown lint, GitHub Pages deploy)
- [ ] Verify hero image renders at `https://f5xc-salesdemos.github.io/api-mcp/`
- [ ] Confirm image scales responsively in the Starlight hero area

🤖 Generated with [Claude Code](https://claude.com/claude-code)