### PR TITLE
fix: correct sidebar navigation ordering for folders and pages

### DIFF
--- a/docs/architecture/0001-dynamic-discovery-pattern.mdx
+++ b/docs/architecture/0001-dynamic-discovery-pattern.mdx
@@ -2,7 +2,7 @@
 title: "ADR-0001: Dynamic Discovery Pattern"
 description: Architecture decision for dynamic tool discovery with meta-tools
 sidebar:
-  order: 1
+  order: 9901
 ---
 
 **Status**: Accepted

--- a/docs/architecture/0002-token-efficiency-strategy.mdx
+++ b/docs/architecture/0002-token-efficiency-strategy.mdx
@@ -2,7 +2,7 @@
 title: "ADR-0002: Token Efficiency Strategy"
 description: Architecture decision for balanced token optimization
 sidebar:
-  order: 2
+  order: 9902
 ---
 
 **Status**: Accepted

--- a/docs/architecture/0003-dual-mode-operation.mdx
+++ b/docs/architecture/0003-dual-mode-operation.mdx
@@ -2,7 +2,7 @@
 title: "ADR-0003: Dual-Mode Operation"
 description: Architecture decision for documentation and authenticated operation modes
 sidebar:
-  order: 3
+  order: 9903
 ---
 
 **Status**: Accepted

--- a/docs/architecture/0004-external-auth-package.mdx
+++ b/docs/architecture/0004-external-auth-package.mdx
@@ -2,7 +2,7 @@
 title: "ADR-0004: External Authentication Package"
 description: Architecture decision for separating authentication into a reusable package
 sidebar:
-  order: 4
+  order: 9904
 ---
 
 **Status**: Accepted

--- a/docs/architecture/0005-generator-architecture.mdx
+++ b/docs/architecture/0005-generator-architecture.mdx
@@ -2,7 +2,7 @@
 title: "ADR-0005: Generator Architecture"
 description: Architecture decision for the tool generation pipeline
 sidebar:
-  order: 5
+  order: 9905
 ---
 
 **Status**: Accepted

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Guides
+description: How-to guides for common F5 XC API MCP Server tasks
+sidebar:
+  order: 5
+---
+
+Step-by-step guides for common operational tasks with the F5 XC API MCP Server.
+
+## Available Guides
+
+- [Quota Management](quota-management/) - Pre-flight quota validation and configurable threshold management
+- [SSL/TLS Configuration](ssl-tls-configuration/) - Configure SSL/TLS for staging environments and custom certificate authorities

--- a/docs/guides/quota-management.mdx
+++ b/docs/guides/quota-management.mdx
@@ -2,7 +2,7 @@
 title: Quota Management
 description: Pre-flight quota validation and configurable threshold management for F5XC resources
 sidebar:
-  order: 1
+  order: 501
 ---
 
 The MCP server automatically checks resource quota availability before

--- a/docs/guides/ssl-tls-configuration.mdx
+++ b/docs/guides/ssl-tls-configuration.mdx
@@ -2,7 +2,7 @@
 title: SSL/TLS Configuration
 description: Configure SSL/TLS for staging environments and custom certificate authorities
 sidebar:
-  order: 2
+  order: 502
 ---
 
 F5 XC staging environments and organizations with custom certificate authorities

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -2,7 +2,7 @@
 title: Environment Variables
 description: Complete reference for all F5XC API MCP Server environment variables
 sidebar:
-  order: 1
+  order: 601
 ---
 
 ## Variable Reference

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Reference
+description: Configuration reference for the F5 XC API MCP Server
+sidebar:
+  order: 6
+---
+
+Configuration and operational reference for the F5 XC API MCP Server.
+
+## Reference Pages
+
+- [Environment Variables](environment-variables/) - Complete reference for all environment variables
+- [Server-Applied Defaults](server-defaults/) - How the server distinguishes user-required fields from server-defaulted values
+- [Resource URIs](resource-uris/) - F5XC resource URI scheme for referencing API resources
+- [Workflow Prompts](workflow-prompts/) - Pre-built multi-step workflow prompts for common operations

--- a/docs/reference/resource-uris.mdx
+++ b/docs/reference/resource-uris.mdx
@@ -2,7 +2,7 @@
 title: Resource URIs
 description: F5XC resource URI scheme for referencing API resources
 sidebar:
-  order: 3
+  order: 603
 ---
 
 The server uses a URI scheme to reference F5 XC API resources. The general format is:

--- a/docs/reference/server-defaults.mdx
+++ b/docs/reference/server-defaults.mdx
@@ -2,7 +2,7 @@
 title: Server-Applied Defaults
 description: How the server distinguishes user-required fields from server-defaulted values
 sidebar:
-  order: 2
+  order: 602
 ---
 
 The F5 XC API uses enhanced metadata to distinguish between field requirement

--- a/docs/reference/workflow-prompts.mdx
+++ b/docs/reference/workflow-prompts.mdx
@@ -2,7 +2,7 @@
 title: Workflow Prompts
 description: Pre-built multi-step workflow prompts for common F5XC operations
 sidebar:
-  order: 4
+  order: 604
 ---
 
 The server includes guided workflow prompts for common multi-step F5XC operations.


### PR DESCRIPTION
## Summary

- Create `index.mdx` for `guides/` and `reference/` directories with explicit sidebar order values
- Update child page order values across `guides/`, `reference/`, and `architecture/` to prevent them from dragging parent directory positions in the sidebar

## Details

Starlight's `getOrder()` for directories returns the **minimum** `sidebar.order` of all child routes. Child pages within `guides/` (order 1-2), `reference/` (order 1-4), and `architecture/` (order 1-5) were dragging their parent directories to the top of the sidebar, causing folders to interleave incorrectly with standalone pages.

The fix uses a numbering scheme where child page orders exceed their parent group's order:
- `guides/` children: 501-502 (group order: 5)
- `reference/` children: 601-604 (group order: 6)
- `architecture/` children: 9901-9905 (group order: 99)

### Resulting sidebar order
1. Installation (1)
2. IDE Setup (2)
3. Authentication (3)
4. Guides (5)
5. Reference (6)
6. Tools Reference (7)
7. Troubleshooting (10)
8. Architecture (99)

## Test plan

- [x] Verified locally with `docs-builder` dev server
- [x] Confirmed sidebar ordering matches expected order
- [x] Confirmed `guides/` and `reference/` index pages render correctly
- [x] Confirmed child pages maintain correct internal ordering within groups
- [ ] CI checks pass

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)