### PR TITLE
fix: standardize example naming prefix from my- to example-

### DIFF
--- a/docs/architecture/0003-dual-mode-operation.mdx
+++ b/docs/architecture/0003-dual-mode-operation.mdx
@@ -149,7 +149,7 @@ Mode: Documentation (no authentication configured)
 To execute this operation, use:
 
 CLI Command:
-  f5xcctl get http-loadbalancer my-lb --namespace shared
+  f5xcctl get http-loadbalancer example-lb --namespace shared
 
 cURL Equivalent:
   curl -X GET https://tenant.console.ves.volterra.io/api/v1/...
@@ -157,7 +157,7 @@ cURL Equivalent:
 
 Expected Response Structure:
   {
-    "name": "my-lb",
+    "name": "example-lb",
     "domains": ["example.com"],
     ...
   }
@@ -169,14 +169,14 @@ Setup Instructions:
 **Authenticated Mode Response**:
 
 ```text
-Mode: Authenticated (tenant: my-tenant)
+Mode: Authenticated (tenant: example-tenant)
 
-API Call: GET /api/v1/config/namespaces/shared/http-loadbalancers/my-lb
+API Call: GET /api/v1/config/namespaces/shared/http-loadbalancers/example-lb
 Status: 200 OK
 
 Response:
 {
-  "name": "my-lb",
+  "name": "example-lb",
   "domains": ["example.com"],
   "origin_pools": [...]
 }

--- a/docs/reference/resource-uris.mdx
+++ b/docs/reference/resource-uris.mdx
@@ -13,5 +13,5 @@ f5xc://{tenant}/{namespace}/{resource-type}/{name}
 
 Examples:
 
-- `f5xc://mytenant/production/http_loadbalancer/my-app`
-- `f5xc://mytenant/system/namespace/default`
+- `f5xc://example-tenant/production/http_loadbalancer/example-app`
+- `f5xc://example-tenant/system/namespace/default`

--- a/docs/tools/admin-console-and-ui/static-component.mdx
+++ b/docs/tools/admin-console-and-ui/static-component.mdx
@@ -18,7 +18,7 @@ Static Component provides tools for listing, and retrieving resources in F5 Dist
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/api/api-crawler.mdx
+++ b/docs/tools/api/api-crawler.mdx
@@ -22,7 +22,7 @@ API Crawler provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/api/api-definition.mdx
+++ b/docs/tools/api/api-definition.mdx
@@ -22,7 +22,7 @@ API Definition provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/api/api-discovery.mdx
+++ b/docs/tools/api/api-discovery.mdx
@@ -22,7 +22,7 @@ API Discovery provides tools for creating, listing, retrieving, updating, and de
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/api/api-group-element.mdx
+++ b/docs/tools/api/api-group-element.mdx
@@ -18,7 +18,7 @@ API Group Element provides tools for listing, and retrieving resources in F5 Dis
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/api/api-group.mdx
+++ b/docs/tools/api/api-group.mdx
@@ -18,7 +18,7 @@ API Group provides tools for listing, and retrieving resources in F5 Distributed
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/api/api-testing.mdx
+++ b/docs/tools/api/api-testing.mdx
@@ -22,7 +22,7 @@ API Testing provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/api/app-api-group.mdx
+++ b/docs/tools/api/app-api-group.mdx
@@ -22,7 +22,7 @@ App API Group provides tools for creating, listing, retrieving, updating, and de
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/api/code-base-integration.mdx
+++ b/docs/tools/api/code-base-integration.mdx
@@ -22,7 +22,7 @@ Code Base Integration provides tools for creating, listing, retrieving, updating
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/api/discovery.mdx
+++ b/docs/tools/api/discovery.mdx
@@ -22,7 +22,7 @@ Discovery provides tools for creating, listing, retrieving, updating, and deleti
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/api/download-certificate.mdx
+++ b/docs/tools/api/download-certificate.mdx
@@ -17,7 +17,7 @@ Download Certificate provides tools for creating resources in F5 Distributed Clo
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Discovery Name x-required... | `my-resource` |
+| `name` | Discovery Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/api/loadbalancer.mdx
+++ b/docs/tools/api/loadbalancer.mdx
@@ -17,7 +17,7 @@ Load Balancer provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the API Definition for the current request. | `my-resource` |
+| `name` | Name The name of the API Definition for the current request. | `example-resource` |
 | `namespace` | Namespace The namespace of the API Definition for the current request. | `system` |
 
 

--- a/docs/tools/api/mark-as-non-api.mdx
+++ b/docs/tools/api/mark-as-non-api.mdx
@@ -17,7 +17,7 @@ Mark As Non API provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the API Definition for the current request. | `my-resource` |
+| `name` | Name The name of the API Definition for the current request. | `example-resource` |
 | `namespace` | Namespace The namespace of the API Definition for the current request. | `system` |
 
 

--- a/docs/tools/api/move-to-inventory.mdx
+++ b/docs/tools/api/move-to-inventory.mdx
@@ -17,7 +17,7 @@ Move To Inventory provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the API Definition for the current request. | `my-resource` |
+| `name` | Name The name of the API Definition for the current request. | `example-resource` |
 | `namespace` | Namespace The namespace of the API Definition for the current request. | `system` |
 
 

--- a/docs/tools/api/remove-from-inventory.mdx
+++ b/docs/tools/api/remove-from-inventory.mdx
@@ -17,7 +17,7 @@ Remove From Inventory provides tools for creating resources in F5 Distributed Cl
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the API Definition for the current request. | `my-resource` |
+| `name` | Name The name of the API Definition for the current request. | `example-resource` |
 | `namespace` | Namespace The namespace of the API Definition for the current request. | `system` |
 
 

--- a/docs/tools/api/unmark-as-non-api.mdx
+++ b/docs/tools/api/unmark-as-non-api.mdx
@@ -17,7 +17,7 @@ Unmark As Non API provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the API Definition for the current request. | `my-resource` |
+| `name` | Name The name of the API Definition for the current request. | `example-resource` |
 | `namespace` | Namespace The namespace of the API Definition for the current request. | `system` |
 
 

--- a/docs/tools/authentication/api-credential.mdx
+++ b/docs/tools/authentication/api-credential.mdx
@@ -19,7 +19,7 @@ API Credential provides tools for creating, listing, and retrieving resources in
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Credential name... | `my-resource` |
+| `name` | Credential name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/authentication/service-credential.mdx
+++ b/docs/tools/authentication/service-credential.mdx
@@ -20,7 +20,7 @@ Service Credential provides tools for creating, listing, retrieving, and updatin
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Credential name... | `my-resource` |
+| `name` | Credential name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/bigip/apm.mdx
+++ b/docs/tools/bigip/apm.mdx
@@ -22,7 +22,7 @@ Apm provides tools for creating, listing, retrieving, updating, and deleting res
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/bigip/bigip-irule.mdx
+++ b/docs/tools/bigip/bigip-irule.mdx
@@ -22,7 +22,7 @@ Bigip Irule provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/bigip/bigip-virtual-server.mdx
+++ b/docs/tools/bigip/bigip-virtual-server.mdx
@@ -19,7 +19,7 @@ Bigip Virtual Server provides tools for listing, retrieving, and updating resour
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/bigip/data-group.mdx
+++ b/docs/tools/bigip/data-group.mdx
@@ -22,7 +22,7 @@ Data Group provides tools for creating, listing, retrieving, updating, and delet
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/bigip/irule.mdx
+++ b/docs/tools/bigip/irule.mdx
@@ -22,7 +22,7 @@ Irule provides tools for creating, listing, retrieving, updating, and deleting r
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/billing-and-usage/invoice-pdf.mdx
+++ b/docs/tools/billing-and-usage/invoice-pdf.mdx
@@ -23,7 +23,7 @@ Invoice Pdf provides tools for listing resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name of the invoice to be downloaded. | `my-resource` |
+| `name` | Name of the invoice to be downloaded. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/billing-and-usage/payment-method.mdx
+++ b/docs/tools/billing-and-usage/payment-method.mdx
@@ -19,7 +19,7 @@ Payment Method provides tools for creating, and deleting resources in F5 Distrib
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This namespace specifies the namespace in which the payment method will be created. | `system` |
-| `name` | Name Name of the payment method. | `my-resource` |
+| `name` | Name Name of the payment method. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/billing-and-usage/primary.mdx
+++ b/docs/tools/billing-and-usage/primary.mdx
@@ -17,7 +17,7 @@ Primary provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the payment method object to be made primary. | `my-resource` |
+| `name` | Name The name of the payment method object to be made primary. | `example-resource` |
 | `namespace` | Namespace The namespace in which the payment method object is present. | `system` |
 
 

--- a/docs/tools/billing-and-usage/quota.mdx
+++ b/docs/tools/billing-and-usage/quota.mdx
@@ -22,7 +22,7 @@ Quota provides tools for creating, listing, retrieving, updating, and deleting r
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/billing-and-usage/secondary.mdx
+++ b/docs/tools/billing-and-usage/secondary.mdx
@@ -17,7 +17,7 @@ Secondary provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the payment method object to be made secondary. | `my-resource` |
+| `name` | Name The name of the payment method object to be made secondary. | `example-resource` |
 | `namespace` | Namespace The namespace in which the payment method object is present. | `system` |
 
 

--- a/docs/tools/billing-and-usage/swap-primary.mdx
+++ b/docs/tools/billing-and-usage/swap-primary.mdx
@@ -17,7 +17,7 @@ Swap Primary provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the payment method object to be updated. | `my-resource` |
+| `name` | Name The name of the payment method object to be updated. | `example-resource` |
 | `namespace` | Namespace The namespace in which the payment method object is present. | `system` |
 
 

--- a/docs/tools/blindfold/get-policy-document.mdx
+++ b/docs/tools/blindfold/get-policy-document.mdx
@@ -17,7 +17,7 @@ Get Policy Document provides tools for retrieving resources in F5 Distributed Cl
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/blindfold/recover.mdx
+++ b/docs/tools/blindfold/recover.mdx
@@ -17,7 +17,7 @@ Recover provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/blindfold/secret-management-access.mdx
+++ b/docs/tools/blindfold/secret-management-access.mdx
@@ -22,7 +22,7 @@ Secret Management Access provides tools for creating, listing, retrieving, updat
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/blindfold/secret-policy-rule.mdx
+++ b/docs/tools/blindfold/secret-policy-rule.mdx
@@ -22,7 +22,7 @@ Secret Policy Rule provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/blindfold/secret-policy.mdx
+++ b/docs/tools/blindfold/secret-policy.mdx
@@ -22,7 +22,7 @@ Secret Policy provides tools for creating, listing, retrieving, updating, and de
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/blindfold/softdelete.mdx
+++ b/docs/tools/blindfold/softdelete.mdx
@@ -17,7 +17,7 @@ Softdelete provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/blindfold/voltshare-admin-policy.mdx
+++ b/docs/tools/blindfold/voltshare-admin-policy.mdx
@@ -22,7 +22,7 @@ Voltshare Admin Policy provides tools for creating, listing, retrieving, updatin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/bot-and-threat-defense/bot-defense-app-infrastructure.mdx
+++ b/docs/tools/bot-and-threat-defense/bot-defense-app-infrastructure.mdx
@@ -22,7 +22,7 @@ Bot Defense App Infrastructure provides tools for creating, listing, retrieving,
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/bot-and-threat-defense/shape-bot-defense-instance.mdx
+++ b/docs/tools/bot-and-threat-defense/shape-bot-defense-instance.mdx
@@ -18,7 +18,7 @@ Shape Bot Defense Instance provides tools for listing, and retrieving resources 
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/bot-and-threat-defense/tpm-api-key.mdx
+++ b/docs/tools/bot-and-threat-defense/tpm-api-key.mdx
@@ -21,7 +21,7 @@ Tpm API Key provides tools for creating, listing, retrieving, and updating resou
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/bot-and-threat-defense/tpm-category.mdx
+++ b/docs/tools/bot-and-threat-defense/tpm-category.mdx
@@ -21,7 +21,7 @@ Tpm Category provides tools for creating, listing, retrieving, and updating reso
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/bot-and-threat-defense/tpm-manager.mdx
+++ b/docs/tools/bot-and-threat-defense/tpm-manager.mdx
@@ -20,7 +20,7 @@ Tpm Manager provides tools for creating, listing, and retrieving resources in F5
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/cdn/cache-purge.mdx
+++ b/docs/tools/cdn/cache-purge.mdx
@@ -17,7 +17,7 @@ Cache Purge provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | CDN Distribution Name x-required... | `my-resource` |
+| `name` | CDN Distribution Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/cdn/cdn-cache-rule.mdx
+++ b/docs/tools/cdn/cdn-cache-rule.mdx
@@ -22,7 +22,7 @@ CDN Cache Rule provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/cdn/cdn-loadbalancer.mdx
+++ b/docs/tools/cdn/cdn-loadbalancer.mdx
@@ -22,7 +22,7 @@ CDN Load Balancer provides tools for creating, listing, retrieving, updating, an
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/cdn/dos-automitigation-rule.mdx
+++ b/docs/tools/cdn/dos-automitigation-rule.mdx
@@ -18,7 +18,7 @@ Dos Automitigation Rule provides tools for retrieving, and deleting resources in
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the Load Balancer. | `my-resource` |
+| `name` | Name Name of the Load Balancer. | `example-resource` |
 | `namespace` | Namespace Namespace of the Load Balancer. | `system` |
 | `dos_automitigation_rule_name` | DoS Mitigation Rule Name Name of the DoS Mitigation Rule. | `-` |
 

--- a/docs/tools/cdn/suggestion.mdx
+++ b/docs/tools/cdn/suggestion.mdx
@@ -17,7 +17,7 @@ Suggestion provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name HTTP load balancer for which this WAF exclusion will be applied. | `my-resource` |
+| `name` | Name HTTP load balancer for which this WAF exclusion will be applied. | `example-resource` |
 | `namespace` | Namespace Namespace of the App type for current request. | `system` |
 
 

--- a/docs/tools/ce-management/fleet.mdx
+++ b/docs/tools/ce-management/fleet.mdx
@@ -22,7 +22,7 @@ Fleet provides tools for creating, listing, retrieving, updating, and deleting r
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/ce-management/network-interface.mdx
+++ b/docs/tools/ce-management/network-interface.mdx
@@ -22,7 +22,7 @@ Network Interface provides tools for creating, listing, retrieving, updating, an
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/ce-management/pre-upgrade-check.mdx
+++ b/docs/tools/ce-management/pre-upgrade-check.mdx
@@ -17,7 +17,7 @@ Pre Upgrade Check provides tools for retrieving resources in F5 Distributed Clou
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Fetch upgrade status for the name of site. | `my-resource` |
+| `name` | Name Fetch upgrade status for the name of site. | `example-resource` |
 | `namespace` | Namespace Fetch upgrade status for the given namespace. | `system` |
 
 ### Query Parameters

--- a/docs/tools/ce-management/upgrade-statu.mdx
+++ b/docs/tools/ce-management/upgrade-statu.mdx
@@ -17,7 +17,7 @@ Upgrade Statu provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Fetch upgrade status for the name of site. | `my-resource` |
+| `name` | Name Fetch upgrade status for the name of site. | `example-resource` |
 | `namespace` | Namespace Fetch upgrade status for the given namespace. | `system` |
 
 

--- a/docs/tools/ce-management/usb-policy.mdx
+++ b/docs/tools/ce-management/usb-policy.mdx
@@ -22,7 +22,7 @@ Usb Policy provides tools for creating, listing, retrieving, updating, and delet
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/certificates/certificate-chain.mdx
+++ b/docs/tools/certificates/certificate-chain.mdx
@@ -22,7 +22,7 @@ Certificate Chain provides tools for creating, listing, retrieving, updating, an
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/certificates/certificate.mdx
+++ b/docs/tools/certificates/certificate.mdx
@@ -22,7 +22,7 @@ Certificate provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/certificates/crl.mdx
+++ b/docs/tools/certificates/crl.mdx
@@ -22,7 +22,7 @@ Crl provides tools for creating, listing, retrieving, updating, and deleting res
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/certificates/trusted-ca-list.mdx
+++ b/docs/tools/certificates/trusted-ca-list.mdx
@@ -22,7 +22,7 @@ Trusted Ca List provides tools for creating, listing, retrieving, updating, and 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/cloud-infrastructure/certified-hardware.mdx
+++ b/docs/tools/cloud-infrastructure/certified-hardware.mdx
@@ -18,7 +18,7 @@ Certified Hardware provides tools for listing, and retrieving resources in F5 Di
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/cloud-infrastructure/cloud-connect.mdx
+++ b/docs/tools/cloud-infrastructure/cloud-connect.mdx
@@ -22,7 +22,7 @@ Cloud Connect provides tools for creating, listing, retrieving, updating, and de
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/cloud-infrastructure/cloud-credentials.mdx
+++ b/docs/tools/cloud-infrastructure/cloud-credentials.mdx
@@ -22,7 +22,7 @@ Cloud Credentials provides tools for creating, listing, retrieving, updating, an
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/cloud-infrastructure/cloud-elastic-ip.mdx
+++ b/docs/tools/cloud-infrastructure/cloud-elastic-ip.mdx
@@ -22,7 +22,7 @@ Cloud Elastic IP provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/cloud-infrastructure/cloud-link.mdx
+++ b/docs/tools/cloud-infrastructure/cloud-link.mdx
@@ -22,7 +22,7 @@ Cloud Link provides tools for creating, listing, retrieving, updating, and delet
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/cloud-infrastructure/cloud-region.mdx
+++ b/docs/tools/cloud-infrastructure/cloud-region.mdx
@@ -19,7 +19,7 @@ Cloud Region provides tools for listing, retrieving, and updating resources in F
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/cloud-infrastructure/force-delete.mdx
+++ b/docs/tools/cloud-infrastructure/force-delete.mdx
@@ -17,7 +17,7 @@ Force Delete provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the Cloud Elastic IP object to be force deleted. | `my-resource` |
+| `name` | Name Name of the Cloud Elastic IP object to be force deleted. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/cloud-infrastructure/reapply-config.mdx
+++ b/docs/tools/cloud-infrastructure/reapply-config.mdx
@@ -17,7 +17,7 @@ Reapply Config provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of Cloud Link. | `my-resource` |
+| `name` | Name Name of Cloud Link. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/container-services/virtual-k8s.mdx
+++ b/docs/tools/container-services/virtual-k8s.mdx
@@ -22,7 +22,7 @@ Virtual K8S provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/container-services/workload-flavor.mdx
+++ b/docs/tools/container-services/workload-flavor.mdx
@@ -22,7 +22,7 @@ Workload Flavor provides tools for creating, listing, retrieving, updating, and 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/container-services/workload.mdx
+++ b/docs/tools/container-services/workload.mdx
@@ -22,7 +22,7 @@ Workload provides tools for creating, listing, retrieving, updating, and deletin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/data-and-privacy-security/data-type.mdx
+++ b/docs/tools/data-and-privacy-security/data-type.mdx
@@ -22,7 +22,7 @@ Data Type provides tools for creating, listing, retrieving, updating, and deleti
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/data-and-privacy-security/geo-config.mdx
+++ b/docs/tools/data-and-privacy-security/geo-config.mdx
@@ -17,7 +17,7 @@ Geo Config provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/data-and-privacy-security/lma-region.mdx
+++ b/docs/tools/data-and-privacy-security/lma-region.mdx
@@ -18,7 +18,7 @@ Lma Region provides tools for listing, and retrieving resources in F5 Distribute
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/data-and-privacy-security/sensitive-data-policy.mdx
+++ b/docs/tools/data-and-privacy-security/sensitive-data-policy.mdx
@@ -22,7 +22,7 @@ Sensitive Data Policy provides tools for creating, listing, retrieving, updating
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/data-intelligence/receiver.mdx
+++ b/docs/tools/data-intelligence/receiver.mdx
@@ -22,7 +22,7 @@ Receiver provides tools for creating, listing, retrieving, updating, and deletin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/ddos/infrastructure-protection/infraprotect-asn-prefix.mdx
+++ b/docs/tools/ddos/infrastructure-protection/infraprotect-asn-prefix.mdx
@@ -22,7 +22,7 @@ Infraprotect Asn Prefix provides tools for creating, listing, retrieving, updati
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/ddos/infrastructure-protection/infraprotect-asn.mdx
+++ b/docs/tools/ddos/infrastructure-protection/infraprotect-asn.mdx
@@ -22,7 +22,7 @@ Infraprotect Asn provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/ddos/infrastructure-protection/infraprotect-deny-list-rule.mdx
+++ b/docs/tools/ddos/infrastructure-protection/infraprotect-deny-list-rule.mdx
@@ -22,7 +22,7 @@ Infraprotect Deny List Rule provides tools for creating, listing, retrieving, up
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/ddos/infrastructure-protection/infraprotect-firewall-rule-group.mdx
+++ b/docs/tools/ddos/infrastructure-protection/infraprotect-firewall-rule-group.mdx
@@ -22,7 +22,7 @@ Infraprotect Firewall Rule Group provides tools for creating, listing, retrievin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/ddos/infrastructure-protection/infraprotect-firewall-rule.mdx
+++ b/docs/tools/ddos/infrastructure-protection/infraprotect-firewall-rule.mdx
@@ -22,7 +22,7 @@ Infraprotect Firewall Rule provides tools for creating, listing, retrieving, upd
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/ddos/infrastructure-protection/infraprotect-firewall-ruleset.mdx
+++ b/docs/tools/ddos/infrastructure-protection/infraprotect-firewall-ruleset.mdx
@@ -19,7 +19,7 @@ Infraprotect Firewall Rule Set provides tools for listing, retrieving, and updat
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/ddos/infrastructure-protection/infraprotect-information.mdx
+++ b/docs/tools/ddos/infrastructure-protection/infraprotect-information.mdx
@@ -17,7 +17,7 @@ Infraprotect Information provides tools for retrieving resources in F5 Distribut
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/ddos/infrastructure-protection/infraprotect-internet-prefix-advertisement.mdx
+++ b/docs/tools/ddos/infrastructure-protection/infraprotect-internet-prefix-advertisement.mdx
@@ -24,7 +24,7 @@ Infraprotect Internet Prefix Advertisement provides tools for creating, listing,
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/ddos/infrastructure-protection/infraprotect-tunnel.mdx
+++ b/docs/tools/ddos/infrastructure-protection/infraprotect-tunnel.mdx
@@ -22,7 +22,7 @@ Infraprotect Tunnel provides tools for creating, listing, retrieving, updating, 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/dns/dns-compliance-checks.mdx
+++ b/docs/tools/dns/dns-compliance-checks.mdx
@@ -22,7 +22,7 @@ DNS Compliance Checks provides tools for creating, listing, retrieving, updating
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/dns/dns-domain.mdx
+++ b/docs/tools/dns/dns-domain.mdx
@@ -22,7 +22,7 @@ DNS Domain provides tools for creating, listing, retrieving, updating, and delet
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/dns/dns-lb-health-check.mdx
+++ b/docs/tools/dns/dns-lb-health-check.mdx
@@ -22,7 +22,7 @@ DNS Lb Health Check provides tools for creating, listing, retrieving, updating, 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/dns/dns-lb-pool.mdx
+++ b/docs/tools/dns/dns-lb-pool.mdx
@@ -22,7 +22,7 @@ DNS Lb Pool provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/dns/dns-load-balancer.mdx
+++ b/docs/tools/dns/dns-load-balancer.mdx
@@ -22,7 +22,7 @@ DNS Load Balancer provides tools for creating, listing, retrieving, updating, an
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/dns/dns-zone.mdx
+++ b/docs/tools/dns/dns-zone.mdx
@@ -22,7 +22,7 @@ DNS Zone provides tools for creating, listing, retrieving, updating, and deletin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/dns/health-statu.mdx
+++ b/docs/tools/dns/health-statu.mdx
@@ -18,7 +18,7 @@ Health Statu provides tools for listing, and retrieving resources in F5 Distribu
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the DNS Load Balancer. | `my-resource` |
+| `name` | Name Name of the DNS Load Balancer. | `example-resource` |
 | `namespace` | Namespace Namespace in which the DNS Load Balancer is present. | `system` |
 
 

--- a/docs/tools/dns/verify.mdx
+++ b/docs/tools/dns/verify.mdx
@@ -17,7 +17,7 @@ Verify provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name dns_domain object, which also domain name. | `my-resource` |
+| `name` | Name Name dns_domain object, which also domain name. | `example-resource` |
 | `namespace` | Namespace Namespace is always system for dns_domain. | `system` |
 
 

--- a/docs/tools/managed-kubernetes/container-registry.mdx
+++ b/docs/tools/managed-kubernetes/container-registry.mdx
@@ -22,7 +22,7 @@ Container Registry provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/managed-kubernetes/k8s-cluster-role-binding.mdx
+++ b/docs/tools/managed-kubernetes/k8s-cluster-role-binding.mdx
@@ -22,7 +22,7 @@ K8S Cluster Role Binding provides tools for creating, listing, retrieving, updat
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/managed-kubernetes/k8s-cluster-role.mdx
+++ b/docs/tools/managed-kubernetes/k8s-cluster-role.mdx
@@ -22,7 +22,7 @@ K8S Cluster Role provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/managed-kubernetes/k8s-pod-security-admission.mdx
+++ b/docs/tools/managed-kubernetes/k8s-pod-security-admission.mdx
@@ -22,7 +22,7 @@ K8S Pod Security Admission provides tools for creating, listing, retrieving, upd
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/managed-kubernetes/k8s-pod-security-policy.mdx
+++ b/docs/tools/managed-kubernetes/k8s-pod-security-policy.mdx
@@ -22,7 +22,7 @@ K8S Pod Security Policy provides tools for creating, listing, retrieving, updati
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/marketplace/addon-service.mdx
+++ b/docs/tools/marketplace/addon-service.mdx
@@ -18,7 +18,7 @@ Addon Service provides tools for listing, and retrieving resources in F5 Distrib
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the addon service. | `my-resource` |
+| `name` | Name Name of the addon service. | `example-resource` |
 | `namespace` | Namespace Namespace to scope the listing of addon_service. | `system` |
 
 ### Query Parameters

--- a/docs/tools/marketplace/addon-subscription.mdx
+++ b/docs/tools/marketplace/addon-subscription.mdx
@@ -22,7 +22,7 @@ Addon Subscription provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/marketplace/cminstance.mdx
+++ b/docs/tools/marketplace/cminstance.mdx
@@ -22,7 +22,7 @@ Cminstance provides tools for creating, listing, retrieving, updating, and delet
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/marketplace/external-connector.mdx
+++ b/docs/tools/marketplace/external-connector.mdx
@@ -22,7 +22,7 @@ External Connector provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/marketplace/generate-token.mdx
+++ b/docs/tools/marketplace/generate-token.mdx
@@ -17,7 +17,7 @@ Generate Token provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Service Name x-required... | `my-resource` |
+| `name` | Service Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/marketplace/navigation-tile.mdx
+++ b/docs/tools/marketplace/navigation-tile.mdx
@@ -18,7 +18,7 @@ Navigation Tile provides tools for listing, and retrieving resources in F5 Distr
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/marketplace/plan.mdx
+++ b/docs/tools/marketplace/plan.mdx
@@ -18,7 +18,7 @@ Plan provides tools for listing, and retrieving resources in F5 Distributed Clou
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/marketplace/third-party-application.mdx
+++ b/docs/tools/marketplace/third-party-application.mdx
@@ -19,7 +19,7 @@ Third Party Application provides tools for listing, retrieving, and updating res
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/network-security/other/fast-acl-rule.mdx
+++ b/docs/tools/network-security/other/fast-acl-rule.mdx
@@ -22,7 +22,7 @@ Fast Acl Rule provides tools for creating, listing, retrieving, updating, and de
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/fast-acl.mdx
+++ b/docs/tools/network-security/other/fast-acl.mdx
@@ -22,7 +22,7 @@ Fast Acl provides tools for creating, listing, retrieving, updating, and deletin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/filter-set.mdx
+++ b/docs/tools/network-security/other/filter-set.mdx
@@ -22,7 +22,7 @@ Filter Set provides tools for creating, listing, retrieving, updating, and delet
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/forward-proxy-policy.mdx
+++ b/docs/tools/network-security/other/forward-proxy-policy.mdx
@@ -22,7 +22,7 @@ Forward Proxy Policy provides tools for creating, listing, retrieving, updating,
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/nat-policy.mdx
+++ b/docs/tools/network-security/other/nat-policy.mdx
@@ -22,7 +22,7 @@ NAT Policy provides tools for creating, listing, retrieving, updating, and delet
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/network-firewall.mdx
+++ b/docs/tools/network-security/other/network-firewall.mdx
@@ -22,7 +22,7 @@ Network Firewall provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/network-policy-rule.mdx
+++ b/docs/tools/network-security/other/network-policy-rule.mdx
@@ -22,7 +22,7 @@ Network Policy Rule provides tools for creating, listing, retrieving, updating, 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/network-policy-set.mdx
+++ b/docs/tools/network-security/other/network-policy-set.mdx
@@ -18,7 +18,7 @@ Network Policy Set provides tools for listing, and retrieving resources in F5 Di
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/network-security/other/network-policy-view.mdx
+++ b/docs/tools/network-security/other/network-policy-view.mdx
@@ -22,7 +22,7 @@ Network Policy View provides tools for creating, listing, retrieving, updating, 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/network-policy.mdx
+++ b/docs/tools/network-security/other/network-policy.mdx
@@ -22,7 +22,7 @@ Network Policy provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/policy-based-routing.mdx
+++ b/docs/tools/network-security/other/policy-based-routing.mdx
@@ -22,7 +22,7 @@ Policy Based Routing provides tools for creating, listing, retrieving, updating,
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/segment-connection.mdx
+++ b/docs/tools/network-security/other/segment-connection.mdx
@@ -19,7 +19,7 @@ Segment Connection provides tools for listing, retrieving, and updating resource
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/network-security/other/segment.mdx
+++ b/docs/tools/network-security/other/segment.mdx
@@ -22,7 +22,7 @@ Segment provides tools for creating, listing, retrieving, updating, and deleting
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network-security/other/service-policy.mdx
+++ b/docs/tools/network-security/other/service-policy.mdx
@@ -22,7 +22,7 @@ Service Policy provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/address-allocator.mdx
+++ b/docs/tools/network/other/address-allocator.mdx
@@ -21,7 +21,7 @@ Address Allocator provides tools for creating, listing, retrieving, and deleting
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/advertise-policy.mdx
+++ b/docs/tools/network/other/advertise-policy.mdx
@@ -22,7 +22,7 @@ Advertise Policy provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/bgp-asn-set.mdx
+++ b/docs/tools/network/other/bgp-asn-set.mdx
@@ -22,7 +22,7 @@ BGP Asn Set provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/bgp-routing-policy.mdx
+++ b/docs/tools/network/other/bgp-routing-policy.mdx
@@ -22,7 +22,7 @@ BGP Routing Policy provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/bgp.mdx
+++ b/docs/tools/network/other/bgp.mdx
@@ -22,7 +22,7 @@ BGP provides tools for creating, listing, retrieving, updating, and deleting res
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/dc-cluster-group.mdx
+++ b/docs/tools/network/other/dc-cluster-group.mdx
@@ -22,7 +22,7 @@ Dc Cluster Group provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/forwarding-class.mdx
+++ b/docs/tools/network/other/forwarding-class.mdx
@@ -22,7 +22,7 @@ Forwarding Class provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/ike-phase1-profile.mdx
+++ b/docs/tools/network/other/ike-phase1-profile.mdx
@@ -22,7 +22,7 @@ Ike Phase1 Profile provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/ike-phase2-profile.mdx
+++ b/docs/tools/network/other/ike-phase2-profile.mdx
@@ -22,7 +22,7 @@ Ike Phase2 Profile provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/ike1.mdx
+++ b/docs/tools/network/other/ike1.mdx
@@ -22,7 +22,7 @@ Ike1 provides tools for creating, listing, retrieving, updating, and deleting re
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/ike2.mdx
+++ b/docs/tools/network/other/ike2.mdx
@@ -22,7 +22,7 @@ Ike2 provides tools for creating, listing, retrieving, updating, and deleting re
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/ip-prefix-set.mdx
+++ b/docs/tools/network/other/ip-prefix-set.mdx
@@ -22,7 +22,7 @@ IP Prefix Set provides tools for creating, listing, retrieving, updating, and de
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/network-connector.mdx
+++ b/docs/tools/network/other/network-connector.mdx
@@ -22,7 +22,7 @@ Network Connector provides tools for creating, listing, retrieving, updating, an
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/public-ip.mdx
+++ b/docs/tools/network/other/public-ip.mdx
@@ -19,7 +19,7 @@ Public IP provides tools for listing, retrieving, and updating resources in F5 D
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/network/other/route.mdx
+++ b/docs/tools/network/other/route.mdx
@@ -22,7 +22,7 @@ Route provides tools for creating, listing, retrieving, updating, and deleting r
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/srv6-network-slice.mdx
+++ b/docs/tools/network/other/srv6-network-slice.mdx
@@ -22,7 +22,7 @@ Srv6 Network Slice provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/subnet.mdx
+++ b/docs/tools/network/other/subnet.mdx
@@ -22,7 +22,7 @@ Subnet provides tools for creating, listing, retrieving, updating, and deleting 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/other/virtual-network.mdx
+++ b/docs/tools/network/other/virtual-network.mdx
@@ -22,7 +22,7 @@ Virtual Network provides tools for creating, listing, retrieving, updating, and 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/network/vpn/tunnel.mdx
+++ b/docs/tools/network/vpn/tunnel.mdx
@@ -22,7 +22,7 @@ Tunnel provides tools for creating, listing, retrieving, updating, and deleting 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/nginx-one/nginx-csg.mdx
+++ b/docs/tools/nginx-one/nginx-csg.mdx
@@ -18,7 +18,7 @@ Nginx Csg provides tools for listing, and retrieving resources in F5 Distributed
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/nginx-one/nginx-instance.mdx
+++ b/docs/tools/nginx-one/nginx-instance.mdx
@@ -18,7 +18,7 @@ Nginx Instance provides tools for listing, and retrieving resources in F5 Distri
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/nginx-one/nginx-server.mdx
+++ b/docs/tools/nginx-one/nginx-server.mdx
@@ -18,7 +18,7 @@ Nginx Server provides tools for listing, and retrieving resources in F5 Distribu
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/nginx-one/nginx-service-discovery.mdx
+++ b/docs/tools/nginx-one/nginx-service-discovery.mdx
@@ -22,7 +22,7 @@ Nginx Service Discovery provides tools for creating, listing, retrieving, updati
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/object-storage/mobile-app-shield.mdx
+++ b/docs/tools/object-storage/mobile-app-shield.mdx
@@ -24,7 +24,7 @@ Mobile App Shield provides tools for listing resources in F5 Distributed Cloud.
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `latest_version_only` | Optional query parameter. If passed, returns only latest version of the objects. | `-` |
-| `name` | Optional query parameter. Name of the stored_object. | `my-resource` |
+| `name` | Optional query parameter. Name of the stored_object. | `example-resource` |
 | `object_type` | Optional query parameter. Type of the stored_object. | `-` |
 | `query_type` | Optional query parameter. The type of search query needs to be performed. Could be EXACT_MATCH or PREFIX_MATCH. EXACT_MATCH returns the objects with exact match on the name filed, while PREFIX_MATCH returns the list of object matching the 'name' prefix. Default is EXACT_MATCH. | `-` |
 

--- a/docs/tools/object-storage/mobile-integrator.mdx
+++ b/docs/tools/object-storage/mobile-integrator.mdx
@@ -24,7 +24,7 @@ Mobile Integrator provides tools for listing resources in F5 Distributed Cloud.
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `latest_version_only` | Optional query parameter. If passed, returns only latest version of the objects. | `-` |
-| `name` | Optional query parameter. Name of the stored_object. | `my-resource` |
+| `name` | Optional query parameter. Name of the stored_object. | `example-resource` |
 | `object_type` | Optional query parameter. Type of the stored_object. | `-` |
 | `query_type` | Optional query parameter. The type of search query needs to be performed. Could be EXACT_MATCH or PREFIX_MATCH. EXACT_MATCH returns the objects with exact match on the name filed, while PREFIX_MATCH returns the list of object matching the 'name' prefix. Default is EXACT_MATCH. | `-` |
 

--- a/docs/tools/object-storage/name.mdx
+++ b/docs/tools/object-storage/name.mdx
@@ -18,7 +18,7 @@ name provides tools for retrieving, and deleting resources in F5 Distributed Clo
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name x-required... | `my-resource` |
+| `name` | Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 | `version` | Version Version of the stored_object in "v\{n\}-\{YY\}-\{MM\}-\{DD\}" formatted string, where n is version number and YY/MM/DD is year, month and date. | `-` |
 | `object_type` | Object_type x-required... | `-` |

--- a/docs/tools/object-storage/object-type.mdx
+++ b/docs/tools/object-storage/object-type.mdx
@@ -18,7 +18,7 @@ object Type provides tools for updating, and deleting resources in F5 Distribute
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name x-required... | `my-resource` |
+| `name` | Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 | `object_type` | Object_type x-required... | `-` |
 

--- a/docs/tools/object-storage/stored-object.mdx
+++ b/docs/tools/object-storage/stored-object.mdx
@@ -25,7 +25,7 @@ Stored Object provides tools for listing resources in F5 Distributed Cloud.
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `latest_version_only` | Optional query parameter. If passed, returns only latest version of the objects. | `-` |
-| `name` | Optional query parameter. Name of the stored_object. | `my-resource` |
+| `name` | Optional query parameter. Name of the stored_object. | `example-resource` |
 | `query_type` | Optional query parameter. The type of search query needs to be performed. Could be EXACT_MATCH or PREFIX_MATCH. EXACT_MATCH returns the objects with exact match on the name filed, while PREFIX_MATCH returns the list of object matching the 'name' prefix. Default is EXACT_MATCH. | `-` |
 
 

--- a/docs/tools/observability/observability/v1-dns-monitor.mdx
+++ b/docs/tools/observability/observability/v1-dns-monitor.mdx
@@ -22,7 +22,7 @@ V1 DNS Monitor provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/observability/observability/v1-http-monitor.mdx
+++ b/docs/tools/observability/observability/v1-http-monitor.mdx
@@ -22,7 +22,7 @@ V1 HTTP Monitor provides tools for creating, listing, retrieving, updating, and 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/rate-limiting/policer.mdx
+++ b/docs/tools/rate-limiting/policer.mdx
@@ -22,7 +22,7 @@ Policer provides tools for creating, listing, retrieving, updating, and deleting
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/rate-limiting/protocol-policer.mdx
+++ b/docs/tools/rate-limiting/protocol-policer.mdx
@@ -22,7 +22,7 @@ Protocol Policer provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/rate-limiting/rate-limiter.mdx
+++ b/docs/tools/rate-limiting/rate-limiter.mdx
@@ -22,7 +22,7 @@ Rate Limiter provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/secops-and-incident-response/malicious-user-mitigation.mdx
+++ b/docs/tools/secops-and-incident-response/malicious-user-mitigation.mdx
@@ -22,7 +22,7 @@ Malicious User Mitigation provides tools for creating, listing, retrieving, upda
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/service-mesh/app-setting.mdx
+++ b/docs/tools/service-mesh/app-setting.mdx
@@ -22,7 +22,7 @@ App Setting provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/service-mesh/app-type.mdx
+++ b/docs/tools/service-mesh/app-type.mdx
@@ -22,7 +22,7 @@ App Type provides tools for creating, listing, retrieving, updating, and deletin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/service-mesh/endpoint.mdx
+++ b/docs/tools/service-mesh/endpoint.mdx
@@ -22,7 +22,7 @@ Endpoint provides tools for creating, listing, retrieving, updating, and deletin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/service-mesh/force-delete.mdx
+++ b/docs/tools/service-mesh/force-delete.mdx
@@ -17,7 +17,7 @@ Force Delete provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the NFV object to be force deleted. | `my-resource` |
+| `name` | Name Name of the NFV object to be force deleted. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/service-mesh/nfv-service.mdx
+++ b/docs/tools/service-mesh/nfv-service.mdx
@@ -22,7 +22,7 @@ NFV Service provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/service-mesh/site-mesh-group.mdx
+++ b/docs/tools/service-mesh/site-mesh-group.mdx
@@ -22,7 +22,7 @@ Site Mesh Group provides tools for creating, listing, retrieving, updating, and 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/service-mesh/suspicious-user.mdx
+++ b/docs/tools/service-mesh/suspicious-user.mdx
@@ -17,7 +17,7 @@ Suspicious User provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name fetch suspicious users based on a given app setting. | `my-resource` |
+| `name` | Name fetch suspicious users based on a given app setting. | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 ### Query Parameters

--- a/docs/tools/service-mesh/virtual-network.mdx
+++ b/docs/tools/service-mesh/virtual-network.mdx
@@ -22,7 +22,7 @@ Virtual Network provides tools for creating, listing, retrieving, updating, and 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/other/mobile-base-config-file.mdx
+++ b/docs/tools/shape/other/mobile-base-config-file.mdx
@@ -17,7 +17,7 @@ Mobile Base Config File provides tools for retrieving resources in F5 Distribute
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Mobile SDK Base Configuration name x-required... | `my-resource` |
+| `name` | Mobile SDK Base Configuration name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/shape/other/mobile-base-config.mdx
+++ b/docs/tools/shape/other/mobile-base-config.mdx
@@ -22,7 +22,7 @@ Mobile Base Config provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/other/mobile-sdk.mdx
+++ b/docs/tools/shape/other/mobile-sdk.mdx
@@ -24,7 +24,7 @@ Mobile Sdk provides tools for listing resources in F5 Distributed Cloud.
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `latest_version_only` | Optional query parameter. If passed, returns only latest version of the objects. | `-` |
-| `name` | Optional query parameter. Name of the stored_object. | `my-resource` |
+| `name` | Optional query parameter. Name of the stored_object. | `example-resource` |
 | `object_type` | Optional query parameter. Type of the stored_object. | `-` |
 | `query_type` | Optional query parameter. The type of search query needs to be performed. Could be EXACT_MATCH or PREFIX_MATCH. EXACT_MATCH returns the objects with exact match on the name filed, while PREFIX_MATCH returns the list of object matching the 'name' prefix. Default is EXACT_MATCH. | `-` |
 

--- a/docs/tools/shape/other/name.mdx
+++ b/docs/tools/shape/other/name.mdx
@@ -17,7 +17,7 @@ name provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name x-required... | `my-resource` |
+| `name` | Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 | `version` | Version Version of the stored_object in "v\{n\}-\{YY\}-\{MM\}-\{DD\}" formatted string, where n is version number and YY/MM/DD is year, month and date. | `-` |
 

--- a/docs/tools/shape/shape-security/alert-gen-policy.mdx
+++ b/docs/tools/shape/shape-security/alert-gen-policy.mdx
@@ -22,7 +22,7 @@ Alert Gen Policy provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/shape-security/alert-template.mdx
+++ b/docs/tools/shape/shape-security/alert-template.mdx
@@ -21,7 +21,7 @@ Alert Template provides tools for creating, listing, retrieving, and deleting re
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/shape-security/allowed-domain.mdx
+++ b/docs/tools/shape/shape-security/allowed-domain.mdx
@@ -21,7 +21,7 @@ Allowed Domain provides tools for creating, listing, retrieving, and deleting re
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/shape-security/bot-allowlist-policy.mdx
+++ b/docs/tools/shape/shape-security/bot-allowlist-policy.mdx
@@ -19,7 +19,7 @@ Bot Allow List Policy provides tools for listing, retrieving, and updating resou
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/shape/shape-security/bot-detection-rule.mdx
+++ b/docs/tools/shape/shape-security/bot-detection-rule.mdx
@@ -20,7 +20,7 @@ Bot Detection Rule provides tools for creating, listing, and retrieving resource
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace... | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/shape-security/bot-endpoint-policy.mdx
+++ b/docs/tools/shape/shape-security/bot-endpoint-policy.mdx
@@ -19,7 +19,7 @@ Bot Endpoint Policy provides tools for listing, retrieving, and updating resourc
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/shape/shape-security/bot-infrastructure.mdx
+++ b/docs/tools/shape/shape-security/bot-infrastructure.mdx
@@ -21,7 +21,7 @@ Bot Infrastructure provides tools for creating, listing, retrieving, and updatin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/shape-security/bot-network-policy.mdx
+++ b/docs/tools/shape/shape-security/bot-network-policy.mdx
@@ -19,7 +19,7 @@ Bot Network Policy provides tools for listing, retrieving, and updating resource
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/shape/shape-security/clone.mdx
+++ b/docs/tools/shape/shape-security/clone.mdx
@@ -17,7 +17,7 @@ Clone provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/shape/shape-security/config.mdx
+++ b/docs/tools/shape/shape-security/config.mdx
@@ -17,7 +17,7 @@ Config provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Application Name Protected application name. | `my-resource` |
+| `name` | Application Name Protected application name. | `example-resource` |
 | `namespace` | Namespace namespace is used to scope the query. | `system` |
 
 

--- a/docs/tools/shape/shape-security/deployment-history.mdx
+++ b/docs/tools/shape/shape-security/deployment-history.mdx
@@ -17,7 +17,7 @@ Deployment History provides tools for retrieving resources in F5 Distributed Clo
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name x-required. | `my-resource` |
+| `name` | Name x-required. | `example-resource` |
 | `namespace` | Namespace x-required. | `system` |
 
 

--- a/docs/tools/shape/shape-security/deployment-statu.mdx
+++ b/docs/tools/shape/shape-security/deployment-statu.mdx
@@ -17,7 +17,7 @@ Deployment Statu provides tools for retrieving resources in F5 Distributed Cloud
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name x-required... | `my-resource` |
+| `name` | Name x-required... | `example-resource` |
 | `namespace` | Name Space x-required... | `system` |
 
 

--- a/docs/tools/shape/shape-security/domain-detail.mdx
+++ b/docs/tools/shape/shape-security/domain-detail.mdx
@@ -23,7 +23,7 @@ Domain Detail provides tools for listing resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name of the domain to GET the details. | `my-resource` |
+| `name` | Name of the domain to GET the details. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/shape/shape-security/js-configuration.mdx
+++ b/docs/tools/shape/shape-security/js-configuration.mdx
@@ -23,7 +23,7 @@ Js Configuration provides tools for listing resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Format we want the script to be returned in. | `my-resource` |
+| `name` | Format we want the script to be returned in. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/shape/shape-security/mitigated-domain.mdx
+++ b/docs/tools/shape/shape-security/mitigated-domain.mdx
@@ -21,7 +21,7 @@ Mitigated Domain provides tools for creating, listing, retrieving, and deleting 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/shape-security/policie.mdx
+++ b/docs/tools/shape/shape-security/policie.mdx
@@ -17,7 +17,7 @@ Policie provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Bot Infra Name Bot Infra Name. | `my-resource` |
+| `name` | Bot Infra Name Bot Infra Name. | `example-resource` |
 | `namespace` | Namespace namespace is used to scope the query. | `system` |
 
 

--- a/docs/tools/shape/shape-security/protected-application.mdx
+++ b/docs/tools/shape/shape-security/protected-application.mdx
@@ -22,7 +22,7 @@ Protected Application provides tools for creating, listing, retrieving, updating
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/shape-security/protected-domain.mdx
+++ b/docs/tools/shape/shape-security/protected-domain.mdx
@@ -21,7 +21,7 @@ Protected Domain provides tools for creating, listing, retrieving, and deleting 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/shape/shape-security/statu.mdx
+++ b/docs/tools/shape/shape-security/statu.mdx
@@ -18,7 +18,7 @@ Statu provides tools for creating, and listing resources in F5 Distributed Cloud
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/shape/shape-security/template.mdx
+++ b/docs/tools/shape/shape-security/template.mdx
@@ -17,7 +17,7 @@ Template provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Application Name Protected application name. | `my-resource` |
+| `name` | Application Name Protected application name. | `example-resource` |
 | `namespace` | Namespace namespace is used to scope the query. | `system` |
 
 

--- a/docs/tools/shape/shape-security/version.mdx
+++ b/docs/tools/shape/shape-security/version.mdx
@@ -17,7 +17,7 @@ Version provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Policy name Policy name. | `my-resource` |
+| `name` | Policy name Policy name. | `example-resource` |
 | `namespace` | Namespace namespace is used to scope the query. | `system` |
 
 

--- a/docs/tools/sites/infrastructure/set-cloud-site-info.mdx
+++ b/docs/tools/sites/infrastructure/set-cloud-site-info.mdx
@@ -17,7 +17,7 @@ Set Cloud Site Info provides tools for creating resources in F5 Distributed Clou
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the object to be configured. | `my-resource` |
+| `name` | Name Name of the object to be configured. | `example-resource` |
 | `namespace` | Namespace Namespace for the object to be configured. | `system` |
 
 

--- a/docs/tools/sites/infrastructure/set-tgw-info.mdx
+++ b/docs/tools/sites/infrastructure/set-tgw-info.mdx
@@ -17,7 +17,7 @@ Set Tgw Info provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the object to be configured. | `my-resource` |
+| `name` | Name Name of the object to be configured. | `example-resource` |
 | `namespace` | Namespace Namespace for the object to be configured. | `system` |
 
 

--- a/docs/tools/sites/infrastructure/set-vip-info.mdx
+++ b/docs/tools/sites/infrastructure/set-vip-info.mdx
@@ -17,7 +17,7 @@ Set VIP Info provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the object to be configured. | `my-resource` |
+| `name` | Name Name of the object to be configured. | `example-resource` |
 | `namespace` | Namespace Namespace for the object to be configured. | `system` |
 
 

--- a/docs/tools/sites/infrastructure/set-vpc-ip-prefixe.mdx
+++ b/docs/tools/sites/infrastructure/set-vpc-ip-prefixe.mdx
@@ -17,7 +17,7 @@ Set VPC IP Prefixe provides tools for creating resources in F5 Distributed Cloud
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the object to be configured. | `my-resource` |
+| `name` | Name Name of the object to be configured. | `example-resource` |
 | `namespace` | Namespace Namespace for the object to be configured. | `system` |
 
 

--- a/docs/tools/sites/infrastructure/set-vpc-k8s-hostname.mdx
+++ b/docs/tools/sites/infrastructure/set-vpc-k8s-hostname.mdx
@@ -17,7 +17,7 @@ Set VPC K8S Hostname provides tools for creating resources in F5 Distributed Clo
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the object to be configured. | `my-resource` |
+| `name` | Name Name of the object to be configured. | `example-resource` |
 | `namespace` | Namespace Namespace for the object to be configured. | `system` |
 
 

--- a/docs/tools/sites/infrastructure/set-vpn-tunnel.mdx
+++ b/docs/tools/sites/infrastructure/set-vpn-tunnel.mdx
@@ -17,7 +17,7 @@ Set Vpn Tunnel provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the object to be configured. | `my-resource` |
+| `name` | Name Name of the object to be configured. | `example-resource` |
 | `namespace` | Namespace Namespace for the object to be configured. | `system` |
 
 

--- a/docs/tools/sites/infrastructure/validate-config.mdx
+++ b/docs/tools/sites/infrastructure/validate-config.mdx
@@ -17,7 +17,7 @@ Validate Config provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the object to be configured. | `my-resource` |
+| `name` | Name Name of the object to be configured. | `example-resource` |
 | `namespace` | Namespace Namespace for the object to be configured. | `system` |
 
 

--- a/docs/tools/sites/observability/network.mdx
+++ b/docs/tools/sites/observability/network.mdx
@@ -17,7 +17,7 @@ Network provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/sites/observability/site.mdx
+++ b/docs/tools/sites/observability/site.mdx
@@ -21,7 +21,7 @@ Site provides tools for creating, listing, retrieving, and updating resources in
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `site` | Site Name of the site. | `-` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/sites/other/aws-tgw-site.mdx
+++ b/docs/tools/sites/other/aws-tgw-site.mdx
@@ -22,7 +22,7 @@ AWS Tgw Site provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/sites/other/aws-vpc-site.mdx
+++ b/docs/tools/sites/other/aws-vpc-site.mdx
@@ -22,7 +22,7 @@ AWS VPC Site provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/sites/other/azure-vnet-site.mdx
+++ b/docs/tools/sites/other/azure-vnet-site.mdx
@@ -22,7 +22,7 @@ AZURE VNET Site provides tools for creating, listing, retrieving, updating, and 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/sites/other/gcp-vpc-site.mdx
+++ b/docs/tools/sites/other/gcp-vpc-site.mdx
@@ -22,7 +22,7 @@ GCP VPC Site provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/sites/other/k8s-cluster.mdx
+++ b/docs/tools/sites/other/k8s-cluster.mdx
@@ -22,7 +22,7 @@ K8S Cluster provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/sites/other/local-kubeconfig.mdx
+++ b/docs/tools/sites/other/local-kubeconfig.mdx
@@ -18,7 +18,7 @@ Local Kubeconfig provides tools for creating, and retrieving resources in F5 Dis
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/sites/other/securemesh-site-v2.mdx
+++ b/docs/tools/sites/other/securemesh-site-v2.mdx
@@ -22,7 +22,7 @@ Securemesh Site V2 provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/sites/other/securemesh-site.mdx
+++ b/docs/tools/sites/other/securemesh-site.mdx
@@ -22,7 +22,7 @@ Securemesh Site provides tools for creating, listing, retrieving, updating, and 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/sites/other/selectee.mdx
+++ b/docs/tools/sites/other/selectee.mdx
@@ -17,7 +17,7 @@ Selectee provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the Virtual Site whose Site selections are to be found. | `my-resource` |
+| `name` | Name Name of the Virtual Site whose Site selections are to be found. | `example-resource` |
 | `namespace` | Namespace Namespace of the Virtual Site whose Site selections are to be found. | `system` |
 
 

--- a/docs/tools/sites/other/state.mdx
+++ b/docs/tools/sites/other/state.mdx
@@ -17,7 +17,7 @@ State provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/sites/other/statu.mdx
+++ b/docs/tools/sites/other/statu.mdx
@@ -17,7 +17,7 @@ Statu provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/sites/other/upgrade-o.mdx
+++ b/docs/tools/sites/other/upgrade-o.mdx
@@ -17,7 +17,7 @@ Upgrade O provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/sites/other/upgrade-sw.mdx
+++ b/docs/tools/sites/other/upgrade-sw.mdx
@@ -17,7 +17,7 @@ Upgrade Sw provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/sites/other/virtual-k8s.mdx
+++ b/docs/tools/sites/other/virtual-k8s.mdx
@@ -22,7 +22,7 @@ Virtual K8S provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/sites/other/virtual-site.mdx
+++ b/docs/tools/sites/other/virtual-site.mdx
@@ -22,7 +22,7 @@ Virtual Site provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/sites/other/voltstack-site.mdx
+++ b/docs/tools/sites/other/voltstack-site.mdx
@@ -22,7 +22,7 @@ Voltstack Site provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/statistics/observability/confirm.mdx
+++ b/docs/tools/statistics/observability/confirm.mdx
@@ -17,7 +17,7 @@ Confirm provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the alert receiver. | `my-resource` |
+| `name` | Name Name of the alert receiver. | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/statistics/observability/download.mdx
+++ b/docs/tools/statistics/observability/download.mdx
@@ -17,7 +17,7 @@ Download provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Report Name... | `my-resource` |
+| `name` | Report Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/statistics/observability/generate.mdx
+++ b/docs/tools/statistics/observability/generate.mdx
@@ -17,7 +17,7 @@ Generate provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/statistics/observability/report-config.mdx
+++ b/docs/tools/statistics/observability/report-config.mdx
@@ -22,7 +22,7 @@ Report Config provides tools for creating, listing, retrieving, updating, and de
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/statistics/observability/report.mdx
+++ b/docs/tools/statistics/observability/report.mdx
@@ -17,7 +17,7 @@ Report provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/statistics/observability/test.mdx
+++ b/docs/tools/statistics/observability/test.mdx
@@ -17,7 +17,7 @@ Test provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the alert receiver. | `my-resource` |
+| `name` | Name Name of the alert receiver. | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/statistics/observability/verify.mdx
+++ b/docs/tools/statistics/observability/verify.mdx
@@ -17,7 +17,7 @@ Verify provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the alert receiver. | `my-resource` |
+| `name` | Name Name of the alert receiver. | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/statistics/other/alert-policy.mdx
+++ b/docs/tools/statistics/other/alert-policy.mdx
@@ -22,7 +22,7 @@ Alert Policy provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/statistics/other/alert-receiver.mdx
+++ b/docs/tools/statistics/other/alert-receiver.mdx
@@ -22,7 +22,7 @@ Alert Receiver provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/statistics/other/flow-anomaly.mdx
+++ b/docs/tools/statistics/other/flow-anomaly.mdx
@@ -18,7 +18,7 @@ Flow Anomaly provides tools for listing, and retrieving resources in F5 Distribu
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/statistics/other/global-log-receiver.mdx
+++ b/docs/tools/statistics/other/global-log-receiver.mdx
@@ -22,7 +22,7 @@ Global Log Receiver provides tools for creating, listing, retrieving, updating, 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/statistics/other/log-receiver.mdx
+++ b/docs/tools/statistics/other/log-receiver.mdx
@@ -22,7 +22,7 @@ Log Receiver provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/statistics/service-mesh/create-http-load-balancer.mdx
+++ b/docs/tools/statistics/service-mesh/create-http-load-balancer.mdx
@@ -17,7 +17,7 @@ Create HTTP Load Balancer provides tools for creating resources in F5 Distribute
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Service Name x-required... | `my-resource` |
+| `name` | Service Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/statistics/service-mesh/create-tcp-load-balancer.mdx
+++ b/docs/tools/statistics/service-mesh/create-tcp-load-balancer.mdx
@@ -17,7 +17,7 @@ Create TCP Load Balancer provides tools for creating resources in F5 Distributed
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Service Name x-required... | `my-resource` |
+| `name` | Service Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/statistics/service-mesh/disable-visibility.mdx
+++ b/docs/tools/statistics/service-mesh/disable-visibility.mdx
@@ -17,7 +17,7 @@ Disable Visibility provides tools for creating resources in F5 Distributed Cloud
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Service Name x-required... | `my-resource` |
+| `name` | Service Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/statistics/service-mesh/discovered-service.mdx
+++ b/docs/tools/statistics/service-mesh/discovered-service.mdx
@@ -18,7 +18,7 @@ Discovered Service provides tools for listing, and retrieving resources in F5 Di
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/statistics/service-mesh/enable-visibility.mdx
+++ b/docs/tools/statistics/service-mesh/enable-visibility.mdx
@@ -17,7 +17,7 @@ Enable Visibility provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Service Name x-required... | `my-resource` |
+| `name` | Service Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/support/other/close.mdx
+++ b/docs/tools/support/other/close.mdx
@@ -17,7 +17,7 @@ Close provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the customer support ticket object to be closed. | `my-resource` |
+| `name` | Name The name of the customer support ticket object to be closed. | `example-resource` |
 | `namespace` | Namespace The namespace in which the support ticket object is present. | `system` |
 
 

--- a/docs/tools/support/other/comment.mdx
+++ b/docs/tools/support/other/comment.mdx
@@ -17,7 +17,7 @@ Comment provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the customer support ticket object to be updated. | `my-resource` |
+| `name` | Name The name of the customer support ticket object to be updated. | `example-resource` |
 | `namespace` | Namespace The namespace in which the support ticket object is present. | `system` |
 
 

--- a/docs/tools/support/other/customer-support.mdx
+++ b/docs/tools/support/other/customer-support.mdx
@@ -20,7 +20,7 @@ Customer Support provides tools for creating, listing, and retrieving resources 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/support/other/escalate.mdx
+++ b/docs/tools/support/other/escalate.mdx
@@ -17,7 +17,7 @@ Escalate provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the customer support ticket object to be escalated. | `my-resource` |
+| `name` | Name The name of the customer support ticket object to be escalated. | `example-resource` |
 | `namespace` | Namespace The namespace in which the support ticket object is present in. | `system` |
 
 

--- a/docs/tools/support/other/priority.mdx
+++ b/docs/tools/support/other/priority.mdx
@@ -17,7 +17,7 @@ Priority provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the customer support ticket object to have its priority changed. | `my-resource` |
+| `name` | Name The name of the customer support ticket object to have its priority changed. | `example-resource` |
 | `namespace` | Namespace The namespace in which the support ticket object is present. | `system` |
 
 

--- a/docs/tools/support/other/reopen.mdx
+++ b/docs/tools/support/other/reopen.mdx
@@ -17,7 +17,7 @@ Reopen provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the customer support ticket object to be open again. | `my-resource` |
+| `name` | Name The name of the customer support ticket object to be open again. | `example-resource` |
 | `namespace` | Namespace The namespace in which the support ticket object is present. | `system` |
 
 

--- a/docs/tools/support/other/ticket-tracking-system.mdx
+++ b/docs/tools/support/other/ticket-tracking-system.mdx
@@ -22,7 +22,7 @@ Ticket Tracking System provides tools for creating, listing, retrieving, updatin
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/telemetry-and-insights/create-http-load-balancer.mdx
+++ b/docs/tools/telemetry-and-insights/create-http-load-balancer.mdx
@@ -17,7 +17,7 @@ Create HTTP Load Balancer provides tools for creating resources in F5 Distribute
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Service Name x-required... | `my-resource` |
+| `name` | Service Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/telemetry-and-insights/create-tcp-load-balancer.mdx
+++ b/docs/tools/telemetry-and-insights/create-tcp-load-balancer.mdx
@@ -17,7 +17,7 @@ Create TCP Load Balancer provides tools for creating resources in F5 Distributed
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Service Name x-required... | `my-resource` |
+| `name` | Service Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/telemetry-and-insights/disable-visibility.mdx
+++ b/docs/tools/telemetry-and-insights/disable-visibility.mdx
@@ -17,7 +17,7 @@ Disable Visibility provides tools for creating resources in F5 Distributed Cloud
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Service Name x-required... | `my-resource` |
+| `name` | Service Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/telemetry-and-insights/discovered-service.mdx
+++ b/docs/tools/telemetry-and-insights/discovered-service.mdx
@@ -18,7 +18,7 @@ Discovered Service provides tools for listing, and retrieving resources in F5 Di
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/telemetry-and-insights/enable-visibility.mdx
+++ b/docs/tools/telemetry-and-insights/enable-visibility.mdx
@@ -17,7 +17,7 @@ Enable Visibility provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Service Name x-required... | `my-resource` |
+| `name` | Service Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/telemetry-and-insights/health-statu.mdx
+++ b/docs/tools/telemetry-and-insights/health-statu.mdx
@@ -17,7 +17,7 @@ Health Statu provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/telemetry-and-insights/status-at-site.mdx
+++ b/docs/tools/telemetry-and-insights/status-at-site.mdx
@@ -18,7 +18,7 @@ Status At Site provides tools for retrieving resources in F5 Distributed Cloud.
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `kind` | Kind... | `-` |
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 ### Query Parameters

--- a/docs/tools/tenant-and-identity/identity/delete.mdx
+++ b/docs/tools/tenant-and-identity/identity/delete.mdx
@@ -17,7 +17,7 @@ Delete provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of OIDC provider object. | `my-resource` |
+| `name` | Name Name of OIDC provider object. | `example-resource` |
 | `namespace` | Namespace Supports only system namespace. | `system` |
 
 

--- a/docs/tools/tenant-and-identity/identity/signup.mdx
+++ b/docs/tools/tenant-and-identity/identity/signup.mdx
@@ -17,7 +17,7 @@ Signup provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Signup name Name of the signup we want to retrieve . The name is returned after a signup object submission. | `my-resource` |
+| `name` | Signup name Name of the signup we want to retrieve . The name is returned after a signup object submission. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/tenant-and-identity/other/allowed-tenant.mdx
+++ b/docs/tools/tenant-and-identity/other/allowed-tenant.mdx
@@ -22,7 +22,7 @@ Allowed Tenant provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/tenant-and-identity/other/assign-namespace-role.mdx
+++ b/docs/tools/tenant-and-identity/other/assign-namespace-role.mdx
@@ -17,7 +17,7 @@ Assign Namespace Role provides tools for updating resources in F5 Distributed Cl
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name of the user group name of the specific group. | `my-resource` |
+| `name` | Name of the user group name of the specific group. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/tenant-and-identity/other/authentication.mdx
+++ b/docs/tools/tenant-and-identity/other/authentication.mdx
@@ -22,7 +22,7 @@ Authentication provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/tenant-and-identity/other/child-tenant-manager.mdx
+++ b/docs/tools/tenant-and-identity/other/child-tenant-manager.mdx
@@ -22,7 +22,7 @@ Child Tenant Manager provides tools for creating, listing, retrieving, updating,
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/tenant-and-identity/other/child-tenant.mdx
+++ b/docs/tools/tenant-and-identity/other/child-tenant.mdx
@@ -22,14 +22,14 @@ Child Tenant provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 
 ### Query Parameters
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `ctm` | Name of the Child Tenant Manager. If this field set, child tenant list will be filtered by given CTM. | `-` |
-| `name` | Filter child tenant list using name of child tenant. | `my-resource` |
+| `name` | Filter child tenant list using name of child tenant. | `example-resource` |
 | `page_limit` | PageLimit will hold the limit of items required per query. Default value is set as 100. | `-` |
 | `page_start` | PageStart will hold the UUID of the first item in the requested page. Response will contain items upto count specified in PageLimit starting from PageStart. | `-` |
 

--- a/docs/tools/tenant-and-identity/other/contact.mdx
+++ b/docs/tools/tenant-and-identity/other/contact.mdx
@@ -22,7 +22,7 @@ Contact provides tools for creating, listing, retrieving, updating, and deleting
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/tenant-and-identity/other/managed-tenant.mdx
+++ b/docs/tools/tenant-and-identity/other/managed-tenant.mdx
@@ -22,7 +22,7 @@ Managed Tenant provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/tenant-and-identity/other/mapper.mdx
+++ b/docs/tools/tenant-and-identity/other/mapper.mdx
@@ -18,7 +18,7 @@ Mapper provides tools for creating, and retrieving resources in F5 Distributed C
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | OIDC provider name Name contains name/alias of underlying OIDC provider. | `my-resource` |
+| `name` | OIDC provider name Name contains name/alias of underlying OIDC provider. | `example-resource` |
 | `namespace` | Namespace Namespace contains namespace of OIDC provider. Namespace should be system. | `system` |
 
 

--- a/docs/tools/tenant-and-identity/other/migrate.mdx
+++ b/docs/tools/tenant-and-identity/other/migrate.mdx
@@ -17,7 +17,7 @@ Migrate provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name... | `my-resource` |
+| `name` | Name... | `example-resource` |
 
 
 ## Configuration Choices

--- a/docs/tools/tenant-and-identity/other/namespace-role.mdx
+++ b/docs/tools/tenant-and-identity/other/namespace-role.mdx
@@ -18,7 +18,7 @@ Namespace Role provides tools for listing, and retrieving resources in F5 Distri
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/tenant-and-identity/other/namespace.mdx
+++ b/docs/tools/tenant-and-identity/other/namespace.mdx
@@ -20,7 +20,7 @@ Namespace provides tools for creating, listing, retrieving, and updating resourc
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/tenant-and-identity/other/oidc-provider.mdx
+++ b/docs/tools/tenant-and-identity/other/oidc-provider.mdx
@@ -21,7 +21,7 @@ OIDC Provider provides tools for creating, listing, retrieving, and updating res
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace Supports only system namespace. | `system` |
-| `name` | Name Name of OIDC provider object. | `my-resource` |
+| `name` | Name Name of OIDC provider object. | `example-resource` |
 
 
 ## Configuration Choices

--- a/docs/tools/tenant-and-identity/other/rbac-policy.mdx
+++ b/docs/tools/tenant-and-identity/other/rbac-policy.mdx
@@ -18,7 +18,7 @@ Rbac Policy provides tools for listing, and retrieving resources in F5 Distribut
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/tenant-and-identity/other/remove-namespace-role.mdx
+++ b/docs/tools/tenant-and-identity/other/remove-namespace-role.mdx
@@ -17,7 +17,7 @@ Remove Namespace Role provides tools for updating resources in F5 Distributed Cl
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name of the user group name of the specific group. | `my-resource` |
+| `name` | Name of the user group name of the specific group. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/tenant-and-identity/other/role.mdx
+++ b/docs/tools/tenant-and-identity/other/role.mdx
@@ -22,7 +22,7 @@ Role provides tools for creating, listing, retrieving, updating, and deleting re
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace Namespace. | `system` |
-| `name` | Name Name of the role. | `my-resource` |
+| `name` | Name Name of the role. | `example-resource` |
 
 
 ## Example Usage

--- a/docs/tools/tenant-and-identity/other/scim.mdx
+++ b/docs/tools/tenant-and-identity/other/scim.mdx
@@ -17,7 +17,7 @@ Scim provides tools for updating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of OIDC provider object. | `my-resource` |
+| `name` | Name Name of OIDC provider object. | `example-resource` |
 | `namespace` | Namespace Supports only system namespace. | `system` |
 
 

--- a/docs/tools/tenant-and-identity/other/tenant-configuration.mdx
+++ b/docs/tools/tenant-and-identity/other/tenant-configuration.mdx
@@ -22,7 +22,7 @@ Tenant Configuration provides tools for creating, listing, retrieving, updating,
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/tenant-and-identity/other/tenant-profile.mdx
+++ b/docs/tools/tenant-and-identity/other/tenant-profile.mdx
@@ -22,7 +22,7 @@ Tenant Profile provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/tenant-and-identity/other/user-group.mdx
+++ b/docs/tools/tenant-and-identity/other/user-group.mdx
@@ -21,7 +21,7 @@ User Group provides tools for creating, listing, retrieving, updating, and delet
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name of the user group name of the specific group. | `my-resource` |
+| `name` | Name of the user group name of the specific group. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/tenant-and-identity/other/user-identification.mdx
+++ b/docs/tools/tenant-and-identity/other/user-identification.mdx
@@ -22,7 +22,7 @@ User Identification provides tools for creating, listing, retrieving, updating, 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/users/state.mdx
+++ b/docs/tools/users/state.mdx
@@ -17,7 +17,7 @@ State provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Token name Token object name to change, it's usually same as metadata.uid. | `my-resource` |
+| `name` | Token name Token object name to change, it's usually same as metadata.uid. | `example-resource` |
 | `namespace` | Token namespace Namespace where token is residing. | `system` |
 
 

--- a/docs/tools/users/token.mdx
+++ b/docs/tools/users/token.mdx
@@ -22,7 +22,7 @@ Token provides tools for creating, listing, retrieving, updating, and deleting r
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/api-endpoint.mdx
+++ b/docs/tools/virtual/other/api-endpoint.mdx
@@ -18,7 +18,7 @@ API Endpoint provides tools for creating, and retrieving resources in F5 Distrib
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | HTTP LoadBalancer Name HTTP LoadBalancer for the current request. | `my-resource` |
+| `name` | HTTP LoadBalancer Name HTTP LoadBalancer for the current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the HTTP LoadBalancer for the current request. | `system` |
 
 ### Query Parameters

--- a/docs/tools/virtual/other/app-firewall.mdx
+++ b/docs/tools/virtual/other/app-firewall.mdx
@@ -22,7 +22,7 @@ App Firewall provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/assign.mdx
+++ b/docs/tools/virtual/other/assign.mdx
@@ -17,7 +17,7 @@ Assign provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the HTTP Load Balancer. | `my-resource` |
+| `name` | Name Name of the HTTP Load Balancer. | `example-resource` |
 | `namespace` | Namespace Namespace of the HTTP Load Balancer. | `system` |
 
 

--- a/docs/tools/virtual/other/available.mdx
+++ b/docs/tools/virtual/other/available.mdx
@@ -17,7 +17,7 @@ Available provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the HTTP Load Balancer. | `my-resource` |
+| `name` | Name Name of the HTTP Load Balancer. | `example-resource` |
 | `namespace` | Namespace Namespace of the HTTP Load Balancer. | `system` |
 
 

--- a/docs/tools/virtual/other/ca-certificate.mdx
+++ b/docs/tools/virtual/other/ca-certificate.mdx
@@ -17,7 +17,7 @@ Ca Certificate provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the proxy object for the custom API. | `my-resource` |
+| `name` | Name The name of the proxy object for the custom API. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 

--- a/docs/tools/virtual/other/calls-by-response-code.mdx
+++ b/docs/tools/virtual/other/calls-by-response-code.mdx
@@ -17,7 +17,7 @@ Calls By Response Code provides tools for creating resources in F5 Distributed C
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Name Virtual Host name for current request. | `my-resource` |
+| `name` | Virtual Host Name Virtual Host name for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the virtual host for current request. | `system` |
 
 

--- a/docs/tools/virtual/other/cluster.mdx
+++ b/docs/tools/virtual/other/cluster.mdx
@@ -22,7 +22,7 @@ Cluster provides tools for creating, listing, retrieving, updating, and deleting
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/create-ticket.mdx
+++ b/docs/tools/virtual/other/create-ticket.mdx
@@ -17,7 +17,7 @@ Create Ticket provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Name... | `my-resource` |
+| `name` | Virtual Host Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/virtual/other/dos-automitigation-rule.mdx
+++ b/docs/tools/virtual/other/dos-automitigation-rule.mdx
@@ -18,7 +18,7 @@ Dos Automitigation Rule provides tools for retrieving, and deleting resources in
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the Load Balancer. | `my-resource` |
+| `name` | Name Name of the Load Balancer. | `example-resource` |
 | `namespace` | Namespace Namespace of the Load Balancer. | `system` |
 | `dos_automitigation_rule_name` | DoS Mitigation Rule Name Name of the DoS Mitigation Rule. | `-` |
 

--- a/docs/tools/virtual/other/enhanced-firewall-policy.mdx
+++ b/docs/tools/virtual/other/enhanced-firewall-policy.mdx
@@ -22,7 +22,7 @@ Enhanced Firewall Policy provides tools for creating, listing, retrieving, updat
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/geo-location-set.mdx
+++ b/docs/tools/virtual/other/geo-location-set.mdx
@@ -22,7 +22,7 @@ Geo Location Set provides tools for creating, listing, retrieving, updating, and
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/get-dns-info.mdx
+++ b/docs/tools/virtual/other/get-dns-info.mdx
@@ -17,7 +17,7 @@ Get DNS Info provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name Name of the HTTP load balancer. | `my-resource` |
+| `name` | Name Name of the HTTP load balancer. | `example-resource` |
 | `namespace` | Namespace Namespace for the HTTP load balancer. | `system` |
 
 

--- a/docs/tools/virtual/other/get-schema-update.mdx
+++ b/docs/tools/virtual/other/get-schema-update.mdx
@@ -17,7 +17,7 @@ Get Schema Update provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the HTTP Loadbalancer for the current request. | `my-resource` |
+| `name` | Name The name of the HTTP Loadbalancer for the current request. | `example-resource` |
 | `namespace` | Namespace The namespace of the HTTP Loadbalancer for the current request. | `system` |
 
 

--- a/docs/tools/virtual/other/healthcheck.mdx
+++ b/docs/tools/virtual/other/healthcheck.mdx
@@ -22,7 +22,7 @@ Health Check provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/http-loadbalancer.mdx
+++ b/docs/tools/virtual/other/http-loadbalancer.mdx
@@ -22,7 +22,7 @@ HTTP Load Balancer provides tools for creating, listing, retrieving, updating, a
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/l7ddos-rps-threshold.mdx
+++ b/docs/tools/virtual/other/l7ddos-rps-threshold.mdx
@@ -17,7 +17,7 @@ L7ddos Rps Threshold provides tools for creating resources in F5 Distributed Clo
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name x-required... | `my-resource` |
+| `name` | Name x-required... | `example-resource` |
 | `namespace` | Namespace x-required... | `system` |
 
 

--- a/docs/tools/virtual/other/learnt-schema.mdx
+++ b/docs/tools/virtual/other/learnt-schema.mdx
@@ -17,7 +17,7 @@ Learnt Schema provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Virtual Host Name for current request. | `my-resource` |
+| `name` | Virtual Host Virtual Host Name for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the App type for current request. | `system` |
 
 ### Query Parameters

--- a/docs/tools/virtual/other/origin-pool.mdx
+++ b/docs/tools/virtual/other/origin-pool.mdx
@@ -22,7 +22,7 @@ Origin Pool provides tools for creating, listing, retrieving, updating, and dele
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/pdf.mdx
+++ b/docs/tools/virtual/other/pdf.mdx
@@ -17,7 +17,7 @@ Pdf provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Virtual Host Name for current request. | `my-resource` |
+| `name` | Virtual Host Virtual Host Name for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the App type for current request. | `system` |
 
 ### Query Parameters

--- a/docs/tools/virtual/other/protocol-inspection.mdx
+++ b/docs/tools/virtual/other/protocol-inspection.mdx
@@ -22,7 +22,7 @@ Protocol Inspection provides tools for creating, listing, retrieving, updating, 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/proxy.mdx
+++ b/docs/tools/virtual/other/proxy.mdx
@@ -22,7 +22,7 @@ Proxy provides tools for creating, listing, retrieving, updating, and deleting r
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/rate-limiter-policy.mdx
+++ b/docs/tools/virtual/other/rate-limiter-policy.mdx
@@ -22,7 +22,7 @@ Rate Limiter Policy provides tools for creating, listing, retrieving, updating, 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/service-policy-rule.mdx
+++ b/docs/tools/virtual/other/service-policy-rule.mdx
@@ -22,7 +22,7 @@ Service Policy Rule provides tools for creating, listing, retrieving, updating, 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/service-policy-set.mdx
+++ b/docs/tools/virtual/other/service-policy-set.mdx
@@ -18,7 +18,7 @@ Service Policy Set provides tools for listing, and retrieving resources in F5 Di
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 | `namespace` | Namespace The namespace in which the configuration object is present. | `system` |
 
 ### Query Parameters

--- a/docs/tools/virtual/other/service-policy.mdx
+++ b/docs/tools/virtual/other/service-policy.mdx
@@ -22,7 +22,7 @@ Service Policy provides tools for creating, listing, retrieving, updating, and d
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/sources-openapi-schema.mdx
+++ b/docs/tools/virtual/other/sources-openapi-schema.mdx
@@ -17,7 +17,7 @@ Sources Openapi Schema provides tools for retrieving resources in F5 Distributed
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Virtual Host Name for current request. | `my-resource` |
+| `name` | Virtual Host Virtual Host Name for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the App type for current request. | `system` |
 
 ### Query Parameters

--- a/docs/tools/virtual/other/stat.mdx
+++ b/docs/tools/virtual/other/stat.mdx
@@ -17,7 +17,7 @@ Stat provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Name Virtual Host for current request. | `my-resource` |
+| `name` | Virtual Host Name Virtual Host for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the App type for current request. | `system` |
 
 

--- a/docs/tools/virtual/other/suggestion.mdx
+++ b/docs/tools/virtual/other/suggestion.mdx
@@ -17,7 +17,7 @@ Suggestion provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name HTTP load balancer for which this API endpoint protection rule applied. | `my-resource` |
+| `name` | Name HTTP load balancer for which this API endpoint protection rule applied. | `example-resource` |
 | `namespace` | Namespace Namespace of the App type for current request. | `system` |
 
 

--- a/docs/tools/virtual/other/swagger-spec.mdx
+++ b/docs/tools/virtual/other/swagger-spec.mdx
@@ -17,7 +17,7 @@ Swagger Spec provides tools for retrieving resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name HTTP load balancer for current request. | `my-resource` |
+| `name` | Name HTTP load balancer for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the HTTP Load Balancer for current request. | `system` |
 
 

--- a/docs/tools/virtual/other/tcp-loadbalancer.mdx
+++ b/docs/tools/virtual/other/tcp-loadbalancer.mdx
@@ -22,7 +22,7 @@ TCP Load Balancer provides tools for creating, listing, retrieving, updating, an
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/top-active.mdx
+++ b/docs/tools/virtual/other/top-active.mdx
@@ -17,7 +17,7 @@ Top Active provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Name Virtual Host name for current request. | `my-resource` |
+| `name` | Virtual Host Name Virtual Host name for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the virtual host for current request. | `system` |
 
 

--- a/docs/tools/virtual/other/top-sensitive-data.mdx
+++ b/docs/tools/virtual/other/top-sensitive-data.mdx
@@ -17,7 +17,7 @@ Top Sensitive Data provides tools for creating resources in F5 Distributed Cloud
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Name Virtual Host name for current request. | `my-resource` |
+| `name` | Virtual Host Name Virtual Host name for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the virtual host for current request. | `system` |
 
 

--- a/docs/tools/virtual/other/udp-loadbalancer.mdx
+++ b/docs/tools/virtual/other/udp-loadbalancer.mdx
@@ -22,7 +22,7 @@ UDP Load Balancer provides tools for creating, listing, retrieving, updating, an
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/unlink-ticket.mdx
+++ b/docs/tools/virtual/other/unlink-ticket.mdx
@@ -17,7 +17,7 @@ Unlink Ticket provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Name... | `my-resource` |
+| `name` | Virtual Host Name... | `example-resource` |
 | `namespace` | Namespace... | `system` |
 
 

--- a/docs/tools/virtual/other/unmerge-sources-openapi-schema.mdx
+++ b/docs/tools/virtual/other/unmerge-sources-openapi-schema.mdx
@@ -17,7 +17,7 @@ Unmerge Sources Openapi Schema provides tools for creating resources in F5 Distr
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Name Virtual Host name for current request. | `my-resource` |
+| `name` | Virtual Host Name Virtual Host name for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the virtual host for current request. | `system` |
 
 

--- a/docs/tools/virtual/other/update-schema.mdx
+++ b/docs/tools/virtual/other/update-schema.mdx
@@ -17,7 +17,7 @@ Update Schema provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Name The name of the HTTP Loadbalancer for the current request. | `my-resource` |
+| `name` | Name The name of the HTTP Loadbalancer for the current request. | `example-resource` |
 | `namespace` | Namespace The namespace of the HTTP Loadbalancer for the current request. | `system` |
 
 

--- a/docs/tools/virtual/other/update-state.mdx
+++ b/docs/tools/virtual/other/update-state.mdx
@@ -17,7 +17,7 @@ Update State provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Name Virtual Host name for current request. | `my-resource` |
+| `name` | Virtual Host Name Virtual Host name for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the virtual host for current request. | `system` |
 
 

--- a/docs/tools/virtual/other/virtual-host.mdx
+++ b/docs/tools/virtual/other/virtual-host.mdx
@@ -22,7 +22,7 @@ Virtual Host provides tools for creating, listing, retrieving, updating, and del
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/docs/tools/virtual/other/vulnerabilitie.mdx
+++ b/docs/tools/virtual/other/vulnerabilitie.mdx
@@ -17,7 +17,7 @@ Vulnerabilitie provides tools for creating resources in F5 Distributed Cloud.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `name` | Virtual Host Name Virtual Host name for current request. | `my-resource` |
+| `name` | Virtual Host Name Virtual Host name for current request. | `example-resource` |
 | `namespace` | Namespace Namespace of the virtual host for current request. | `system` |
 
 

--- a/docs/tools/virtual/other/waf-exclusion-policy.mdx
+++ b/docs/tools/virtual/other/waf-exclusion-policy.mdx
@@ -22,7 +22,7 @@ WAF Exclusion Policy provides tools for creating, listing, retrieving, updating,
 | Parameter | Description | Example |
 |-----------|-------------|--------|
 | `namespace` | Namespace This defines the workspace within which each the configuration object is to be created. | `system` |
-| `name` | Name The name of the configuration object to be fetched. | `my-resource` |
+| `name` | Name The name of the configuration object to be fetched. | `example-resource` |
 
 ### Query Parameters
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -346,7 +346,7 @@ function generateMarkdown(resourceDoc: ResourceDoc): string {
   // Default examples for common parameters
   const DEFAULT_EXAMPLES: Record<string, string> = {
     namespace: "system",
-    name: "my-resource",
+    name: "example-resource",
     response_format: "GET_RSP_FORMAT_DEFAULT",
   };
 

--- a/src/tools/discovery/index.ts
+++ b/src/tools/discovery/index.ts
@@ -412,7 +412,7 @@ export const DISCOVERY_TOOLS = {
         },
         pathParams: {
           type: "object",
-          description: "Path parameters to validate (e.g., { namespace: 'default', name: 'my-resource' })",
+          description: "Path parameters to validate (e.g., { namespace: 'default', name: 'example-resource' })",
           additionalProperties: { type: "string" },
         },
         queryParams: {

--- a/src/tools/discovery/schema.ts
+++ b/src/tools/discovery/schema.ts
@@ -189,8 +189,8 @@ export function getMutuallyExclusiveFields(toolName: string): MutuallyExclusiveG
  * Smart defaults for common field patterns
  */
 const SMART_DEFAULTS: Record<string, (toolName: string, schema?: ResolvedSchema) => unknown> = {
-  name: (toolName) => `my-${extractResourceFromTool(toolName)}`,
-  "metadata.name": (toolName) => `my-${extractResourceFromTool(toolName)}`,
+  name: (toolName) => `example-${extractResourceFromTool(toolName)}`,
+  "metadata.name": (toolName) => `example-${extractResourceFromTool(toolName)}`,
   namespace: () => "default",
   "metadata.namespace": () => "default",
   port: () => 80,

--- a/src/tools/discovery/suggest-params.ts
+++ b/src/tools/discovery/suggest-params.ts
@@ -49,7 +49,7 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // HTTP Load Balancer examples
   "f5xc-api-virtual-http-loadbalancer-create": {
     metadata: {
-      name: "my-http-lb",
+      name: "example-http-lb",
       namespace: "default",
       labels: {
         "ves.io/site": "aws-us-west-2",
@@ -81,7 +81,7 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // Origin Pool examples
   "f5xc-api-virtual-origin-pool-create": {
     metadata: {
-      name: "my-origin-pool",
+      name: "example-origin-pool",
       namespace: "default",
     },
     spec: {
@@ -110,7 +110,7 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // TCP Load Balancer examples
   "f5xc-api-virtual-tcp-loadbalancer-create": {
     metadata: {
-      name: "my-tcp-lb",
+      name: "example-tcp-lb",
       namespace: "default",
     },
     spec: {
@@ -161,7 +161,7 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // DNS Load Balancer examples
   "f5xc-api-dns-load-balancer-create": {
     metadata: {
-      name: "my-dns-lb",
+      name: "example-dns-lb",
       namespace: "system",
     },
     spec: {
@@ -188,7 +188,7 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // Certificate examples
   "f5xc-api-certificates-certificate-create": {
     metadata: {
-      name: "my-certificate",
+      name: "example-certificate",
       namespace: "system",
     },
     spec: {
@@ -206,7 +206,7 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // Namespace examples
   "f5xc-api-system-namespace-create": {
     metadata: {
-      name: "my-namespace",
+      name: "example-namespace",
       namespace: "system",
     },
     spec: {},
@@ -215,7 +215,7 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // WAF Policy examples
   "f5xc-api-app-firewall-policy-create": {
     metadata: {
-      name: "my-waf-policy",
+      name: "example-waf-policy",
       namespace: "default",
     },
     spec: {
@@ -230,7 +230,7 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // Service Policy examples
   "f5xc-api-network-security-service-policy-create": {
     metadata: {
-      name: "my-service-policy",
+      name: "example-service-policy",
       namespace: "default",
     },
     spec: {
@@ -258,14 +258,14 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // Network Firewall examples
   "f5xc-api-network-security-network-firewall-create": {
     metadata: {
-      name: "my-network-firewall",
+      name: "example-network-firewall",
       namespace: "system",
     },
     spec: {
       active_service_policies: {
         policies: [
           {
-            name: "my-service-policy",
+            name: "example-service-policy",
             namespace: "default",
           },
         ],
@@ -276,7 +276,7 @@ const COMMON_EXAMPLES: Record<string, Record<string, unknown>> = {
   // Rate Limiter examples
   "f5xc-api-rate-limiting-rate-limiter-create": {
     metadata: {
-      name: "my-rate-limiter",
+      name: "example-rate-limiter",
       namespace: "default",
     },
     spec: {


### PR DESCRIPTION
## Summary

- Replace all `my-` prefixed example names with `example-` across source code (smart defaults, curated examples), handwritten docs, and regenerated tool documentation
- Affects 4 source files, 2 doc files, and ~300 regenerated MDX files in `docs/tools/`

## Changes

| File | What changed |
|------|-------------|
| `scripts/generate-docs.ts` | DEFAULT_EXAMPLES: `my-resource` -> `example-resource` |
| `src/tools/discovery/schema.ts` | SMART_DEFAULTS: `my-` -> `example-` prefix |
| `src/tools/discovery/suggest-params.ts` | COMMON_EXAMPLES: 11 `my-` names -> `example-` |
| `src/tools/discovery/index.ts` | Description text: `my-resource` -> `example-resource` |
| `docs/architecture/0003-dual-mode-operation.mdx` | 5 `my-` references -> `example-` |
| `docs/reference/resource-uris.mdx` | URI example tenant and app names |
| `docs/tools/**` | Regenerated with updated defaults |

## Test plan

- [x] `grep -rn '"my-' src/tools/discovery/` returns zero matches
- [x] `npm run generate-docs` succeeds without errors
- [x] Spot-checked `docs/tools/dns/dns-zone.mdx` shows `example-resource`
- [x] Spot-checked `docs/tools/cdn/cdn-loadbalancer.mdx` has no `my-` references
- [ ] CI passes (super-linter with biome formatting)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)