### PR TITLE
fix: correct Claude Code CLI docs — broken protocol test, missing doc mode, wrong config paths

### DIFF
--- a/docs/ide-setup.mdx
+++ b/docs/ide-setup.mdx
@@ -73,7 +73,17 @@ Just closing the window is not sufficient.
 
 ## Claude Code CLI
 
-### Quick Install
+### Documentation Mode
+
+No credentials required - explore APIs, view schemas, get CURL examples:
+
+```bash
+claude mcp add f5xc-api -- npx @f5xc-salesdemos/api-mcp
+```
+
+### Execution Mode
+
+Add credentials to execute API calls directly:
 
 ```bash
 claude mcp add f5xc-api \
@@ -119,7 +129,11 @@ Create `.mcp.json` in your project root:
 
 ### Global Configuration
 
-For system-wide availability, add to `~/.claude/settings.local.json`.
+For system-wide availability, use `--scope user`:
+
+```bash
+claude mcp add f5xc-api --scope user -- npx @f5xc-salesdemos/api-mcp
+```
 
 ### Usage
 
@@ -456,7 +470,7 @@ The standard MCP configuration schema used by Claude Desktop, Claude Code, Cline
 | Claude Desktop (Windows) | `%APPDATA%\Claude\claude_desktop_config.json`                     |
 | Claude Desktop (Linux)   | `~/.config/Claude/claude_desktop_config.json`                     |
 | Claude Code (Project)    | `.mcp.json` in project root                                       |
-| Claude Code (Global)     | `~/.claude/mcp.json`                                              |
+| Claude Code (User)       | `~/.claude.json`                                                  |
 | OpenCode (Project)       | `opencode.json` or `opencode.jsonc` in project root               |
 | OpenCode (Global)        | `~/.config/opencode/opencode.json`                                |
 | VS Code (Cline)          | Cline extension settings                                          |

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -50,7 +50,7 @@ npx @f5xc-salesdemos/api-mcp --version
 ### MCP Protocol Test
 
 ```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | npx @f5xc-salesdemos/api-mcp
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}' | npx @f5xc-salesdemos/api-mcp
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary

- Fix broken MCP Protocol Test command in `docs/installation.mdx` — add required `protocolVersion` and `clientInfo` fields
- Add separate Documentation Mode and Execution Mode sections for Claude Code CLI in `docs/ide-setup.mdx`, matching the Claude Desktop structure
- Correct Global Configuration section to show `claude mcp add --scope user` instead of referencing a wrong file path
- Fix Configuration File Locations table: `~/.claude/mcp.json` changed to `~/.claude.json` to match actual `claude mcp add --scope user` behavior

Closes #44

## Test plan

- [ ] `npx @f5xc-salesdemos/api-mcp --version` prints version
- [ ] MCP Protocol Test command from `docs/installation.mdx` returns a valid JSON-RPC response
- [ ] `claude mcp add f5xc-api -- npx @f5xc-salesdemos/api-mcp` installs without credentials (documentation mode)
- [ ] `claude mcp add f5xc-api --scope user -- npx @f5xc-salesdemos/api-mcp` stores in `~/.claude.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)